### PR TITLE
Rm untagged assets for all runs

### DIFF
--- a/housekeeper/store/api.py
+++ b/housekeeper/store/api.py
@@ -185,7 +185,7 @@ def delete_asset(asset_obj):
     asset_obj.delete()
 
 
-def clean_up(root_path, run_obj, force=False):
+def clean_up(root_path, run_obj, force=False, untagged_only=False):
     """Clean up files for an analysis."""
     # check if run is ready
     if not force and not all([run_obj.archived_at, run_obj.delivered_at]):
@@ -196,12 +196,14 @@ def clean_up(root_path, run_obj, force=False):
             if not asset.archive_type:
                 asset.delete()
             else:
-                asset.is_local = False
+                if not untagged_only:
+                    asset.is_local = False
 
-        run_dir = get_rundir(root_path, run_obj.case.name, run_obj)
-        log.info("removing rundir: %s", run_dir)
-        delete_dir(run_dir)
-        run_obj.cleanedup_at = datetime.datetime.now()
+        if not untagged_only:
+            run_dir = get_rundir(root_path, run_obj.case.name, run_obj)
+            log.info("removing rundir: %s", run_dir)
+            delete_dir(run_dir)
+            run_obj.cleanedup_at = datetime.datetime.now()
 
 
 def postpone(run_obj, time=datetime.timedelta(days=30)):

--- a/housekeeper/store/cli.py
+++ b/housekeeper/store/cli.py
@@ -209,13 +209,13 @@ def delete_case(context, yes, case_name):
 @click.option('-f', '--force', is_flag=True,
               help='auto confirm and override sanity checks')
 @click.option('-d', '--date', help="date of the particular run")
-@click.option('-a', '--all', 'clean_all', is_flag=True, default=False, help="select all runs")
+@click.option('-l', '--limit', default=20)
 @click.option('-b', '--before', help='runs before a date')
 @click.option('-a', '--after', help='runs after a date')
 @click.option('-u', '--untagged-only', is_flag=True, default=False, help='only remove assets without archive type')
 @click.argument('case_name', required=False)
 @click.pass_context
-def clean(context, force, date, clean_all, before, after, untagged_only, case_name):
+def clean(context, force, date, limit, before, after, untagged_only, case_name):
     """Clean up files for an analysis.
     Providing a CASE_NAME will ignore --before, --after options
     """
@@ -225,7 +225,7 @@ def clean(context, force, date, clean_all, before, after, untagged_only, case_na
     else:
         before_date = parse_date(before) if before else None
         after_date = parse_date(after) if after else None
-        run_objs = api.runs(before=before_date, after=after_date)
+        run_objs = api.runs(before=before_date, after=after_date).limit(limit)
         if run_objs.first() is None:
             log.error("no runs found")
             context.abort()

--- a/housekeeper/store/cli.py
+++ b/housekeeper/store/cli.py
@@ -209,14 +209,34 @@ def delete_case(context, yes, case_name):
 @click.option('-f', '--force', is_flag=True,
               help='auto confirm and override sanity checks')
 @click.option('-d', '--date', help="date of the particular run")
-@click.argument('case_name')
+@click.option('-a', '--all', 'clean_all', is_flag=True, default=False, help="select all runs")
+@click.option('-b', '--before', help='runs before a date')
+@click.option('-a', '--after', help='runs after a date')
+@click.option('-u', '--untagged-only', is_flag=True, default=False, help='only remove assets without archive type')
+@click.argument('case_name', required=False)
 @click.pass_context
-def clean(context, force, date, case_name):
-    """Clean up files for an analysis."""
+def clean(context, force, date, clean_all, before, after, untagged_only, case_name):
+    """Clean up files for an analysis.
+    Providing a CASE_NAME will ignore --before, --after options
+    """
     manager = api.manager(context.obj['database'])
-    run_obj = run_orabort(context, case_name, date)
-    if force or click.confirm('Are you sure?'):
-        api.clean_up(context.obj['root'], run_obj, force=force)
+    if case_name:
+        run_objs = [run_orabort(context, case_name, date)]
+    else:
+        before_date = parse_date(before) if before else None
+        after_date = parse_date(after) if after else None
+        run_objs = api.runs(before=before_date, after=after_date)
+        if run_objs.first() is None:
+            log.error("no runs found")
+            context.abort()
+
+    if force or click.confirm('Cleaning following runs: {}'.
+                              format([ run_obj.case.name for run_obj in run_objs ])):
+        if untagged_only:
+            force = True
+        for run_obj in run_objs:
+            api.clean_up(context.obj['root'], run_obj, force=force,
+                         untagged_only=untagged_only)
         manager.commit()
 
 


### PR DESCRIPTION
You can clean all assets that have no archive type, from all runs, between two dates.