### PR TITLE
Add X FC name ending to X cleanup script

### DIFF
--- a/scripts/fcs_ls.bash
+++ b/scripts/fcs_ls.bash
@@ -9,7 +9,7 @@ DEMUX_DIR=$(readlink -m ${DEMUX_DIR})
 
 # find all fastq files that are older than certain date
 # filter out the X FCs only
-FASTQS=$(find ${DEMUX_DIR}/{*ALXX,*CCXX,*CCXY} -name *.fastq.gz ! -newermt ${CUTOFF_DATE})
+FASTQS=$(find ${DEMUX_DIR}/{*ALXX,*CCXX,*CCXY,*CCX2} -name *.fastq.gz ! -newermt ${CUTOFF_DATE})
 
 # get the rundirs
 RUN_DIRS=()


### PR DESCRIPTION
Illumina is adding a new HiSeq X ending to the FC name. This is our only fix for that :)