### PR TITLE
add new tags in CLI

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -11,86 +11,96 @@ from housekeeper.store import Store
 @click.pass_context
 def add(context):
     """Add things to the store."""
-    context.obj['db'] = Store(context.obj['database'], context.obj['root'])
+    context.obj["db"] = Store(context.obj["database"], context.obj["root"])
 
 
 @add.command()
-@click.argument('name')
+@click.argument("name")
 @click.pass_context
 def bundle(context, name):
     """Add a new bundle."""
-    if context.obj['db'].bundle(name):
-        click.echo(click.style('bundle name already exists', fg='yellow'))
+    if context.obj["db"].bundle(name):
+        click.echo(click.style("bundle name already exists", fg="yellow"))
         context.abort()
-    new_bundle = context.obj['db'].new_bundle(name)
-    context.obj['db'].add_commit(new_bundle)
+    new_bundle = context.obj["db"].new_bundle(name)
+    context.obj["db"].add_commit(new_bundle)
 
     # add default version
-    new_version = context.obj['db'].new_version(created_at=new_bundle.created_at)
+    new_version = context.obj["db"].new_version(created_at=new_bundle.created_at)
     new_version.bundle = new_bundle
-    context.obj['db'].add_commit(new_version)
+    context.obj["db"].add_commit(new_version)
 
-    click.echo(click.style(f"new bundle added: {new_bundle.name} ({new_bundle.id})", fg='green'))
+    click.echo(
+        click.style(
+            f"new bundle added: {new_bundle.name} ({new_bundle.id})", fg="green"
+        )
+    )
 
 
-@add.command('file')
-@click.option('-t', '--tag', 'tags', multiple=True, help='tag to associate the file by')
-@click.option('-a', '--archive', is_flag=True, help='mark file to be archived')
-@click.argument('bundle_name')
-@click.argument('path')
+@add.command("file")
+@click.option("-t", "--tag", "tags", multiple=True, help="tag to associate the file by")
+@click.option("-a", "--archive", is_flag=True, help="mark file to be archived")
+@click.argument("bundle_name")
+@click.argument("path")
 @click.pass_context
 def file_cmd(context, tags, archive, bundle_name, path):
     """Add a file to a bundle."""
-    bundle_obj = context.obj['db'].bundle(bundle_name)
+    bundle_obj = context.obj["db"].bundle(bundle_name)
     if bundle_obj is None:
-        click.echo(click.style(f"unknown bundle: {bundle_name}", fg='red'))
+        click.echo(click.style(f"unknown bundle: {bundle_name}", fg="red"))
         context.abort()
     version_obj = bundle_obj.versions[0]
-    new_file = context.obj['db'].new_file(
+    new_file = context.obj["db"].new_file(
         path=str(Path(path).absolute()),
         to_archive=archive,
-        tags=[context.obj['db'].tag(tag_name) if context.obj['db'].tag(tag_name) else
-              context.obj['db'].new_tag(tag_name) for tag_name in tags]
+        tags=[
+            context.obj["db"].tag(tag_name)
+            if context.obj["db"].tag(tag_name)
+            else context.obj["db"].new_tag(tag_name)
+            for tag_name in tags
+        ],
     )
     new_file.version = version_obj
-    context.obj['db'].add_commit(new_file)
-    click.echo(click.style(f"new file added: {new_file.path} ({new_file.id})", fg='green'))
+    context.obj["db"].add_commit(new_file)
+    click.echo(
+        click.style(f"new file added: {new_file.path} ({new_file.id})", fg="green")
+    )
 
 
 @add.command()
-@click.argument('tags', nargs=-1)
-@click.option('-f', '--file-id' , 'file_id', type=int)
+@click.argument("tags", nargs=-1)
+@click.option("-f", "--file-id", "file_id", type=int)
 @click.pass_context
-def tag(context: click.Context, tags: List[str], file_id: int=None):
+def tag(context: click.Context, tags: List[str], file_id: int = None):
     """Add tags to an existing file."""
     file_obj = None
 
     if file_id:
-        file_obj = context.obj['db'].file_(file_id)
+        file_obj = context.obj["db"].file_(file_id)
         if not file_obj:
-            print(click.style('unable to find file', fg='red'))
+            print(click.style("unable to find file", fg="red"))
             context.abort()
 
     for tag_name in tags:
-        tag_obj = context.obj['db'].tag(tag_name)
+        tag_obj = context.obj["db"].tag(tag_name)
 
         if not tag_obj:
-            print(click.style(f"{tag_name}: tag created", fg='green'))
-            tag_obj = context.obj['db'].new_tag(tag_name)
+            print(click.style(f"{tag_name}: tag created", fg="green"))
+            tag_obj = context.obj["db"].new_tag(tag_name)
 
         if not file_obj:
             continue
 
         if tag_obj in file_obj.tags:
-            print(click.style(f"{tag_name}: tag already added", fg='yellow'))
+            print(click.style(f"{tag_name}: tag already added", fg="yellow"))
             continue
 
         file_obj.tags.append(tag_obj)
 
-    context.obj['db'].commit()
+    context.obj["db"].commit()
 
     if not file_obj:
         context.exit()
 
     all_tags = (tag.name for tag in file_obj.tags)
-    print(click.style(f"file tags: {', '.join(all_tags)}", fg='blue'))
+    print(click.style(f"file tags: {', '.join(all_tags)}", fg="blue"))

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -63,6 +63,7 @@ def file_cmd(context, tags, archive, bundle_name, path):
 @click.pass_context
 def tag(context: click.Context, tags: List[str], file_id: int=None):
     """Add tags to an existing file."""
+file_obj = None
 
     if file_id:
         file_obj = context.obj['db'].file_(file_id)

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -58,8 +58,8 @@ def file_cmd(context, tags, archive, bundle_name, path):
 
 
 @add.command()
-@click.argument('file_id', type=int, required=False)
 @click.argument('tags', nargs=-1)
+@click.option('-f', '--file-id' , 'file_id', type=int)
 @click.pass_context
 def tag(context: click.Context, tags: List[str], file_id: int=None):
     """Add tags to an existing file."""

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -63,7 +63,7 @@ def file_cmd(context, tags, archive, bundle_name, path):
 @click.pass_context
 def tag(context: click.Context, tags: List[str], file_id: int=None):
     """Add tags to an existing file."""
-file_obj = None
+    file_obj = None
 
     if file_id:
         file_obj = context.obj['db'].file_(file_id)

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -57,11 +57,11 @@ def file_cmd(context, tags, archive, bundle_name, path):
     click.echo(click.style(f"new file added: {new_file.path} ({new_file.id})", fg='green'))
 
 
-@add.command()
+@add.command('file-tags')
 @click.argument('file_id', type=int)
 @click.argument('tags', nargs=-1)
 @click.pass_context
-def tag(context: click.Context, file_id: int, tags: List[str]):
+def file_tags(context: click.Context, file_id: int, tags: List[str]):
     """Add tags to an existing file."""
     file_obj = context.obj['db'].file_(file_id)
     if file_obj is None:
@@ -78,3 +78,17 @@ def tag(context: click.Context, file_id: int, tags: List[str]):
     context.obj['db'].commit()
     all_tags = (tag.name for tag in file_obj.tags)
     print(click.style(f"file tags: {', '.join(all_tags)}", fg='blue'))
+
+
+@add.command()
+@click.argument('name')
+@click.pass_context
+def tag(context, name):
+    """Add a new tag."""
+    if context.obj['db'].tag(name):
+        click.echo(click.style('tag name already exists', fg='yellow'))
+        context.abort()
+    new_tag = context.obj['db'].new_tag(name)
+    context.obj['db'].add_commit(new_tag)
+
+    click.echo(click.style(f"new tag added: {new_tag.name} ({new_tag.id})", fg='green'))

--- a/housekeeper/store/api/add.py
+++ b/housekeeper/store/api/add.py
@@ -28,30 +28,36 @@ class AddHandler(BaseHandler):
 
         The format of the input dict is defined in the `schema` module.
         """
-        bundle_obj = self.bundle(data['name'])
-        if bundle_obj and self.version(bundle_obj.name, data['created']):
-            LOG.debug('version of bundle already added')
+        bundle_obj = self.bundle(data["name"])
+        if bundle_obj and self.version(bundle_obj.name, data["created"]):
+            LOG.debug("version of bundle already added")
             return None
 
         if bundle_obj is None:
-            bundle_obj = self.new_bundle(name=data['name'], created_at=data['created'])
+            bundle_obj = self.new_bundle(name=data["name"], created_at=data["created"])
 
-        version_obj = self.new_version(created_at=data['created'], expires_at=data.get('expires'))
+        version_obj = self.new_version(
+            created_at=data["created"], expires_at=data.get("expires")
+        )
 
-        tag_names = set(tag_name for file_data in data['files'] for tag_name in file_data['tags'])
+        tag_names = set(
+            tag_name for file_data in data["files"] for tag_name in file_data["tags"]
+        )
         tag_map = self._build_tags(tag_names)
 
-        for file_data in data['files']:
-            if isinstance(file_data['path'], str):
-                paths = [file_data['path']]
+        for file_data in data["files"]:
+            if isinstance(file_data["path"], str):
+                paths = [file_data["path"]]
             else:
-                paths = file_data['path']
+                paths = file_data["path"]
             for path in paths:
                 LOG.debug("adding file: %s", path)
                 if not Path(path).exists():
                     raise FileNotFoundError(path)
-                tags = [tag_map[tag_name] for tag_name in file_data['tags']]
-                new_file = self.new_file(path, to_archive=file_data['archive'], tags=tags)
+                tags = [tag_map[tag_name] for tag_name in file_data["tags"]]
+                new_file = self.new_file(
+                    path, to_archive=file_data["archive"], tags=tags
+                )
                 version_obj.files.append(new_file)
 
         version_obj.bundle = bundle_obj
@@ -73,16 +79,24 @@ class AddHandler(BaseHandler):
         new_bundle = self.Bundle(name=name, created_at=created_at)
         return new_bundle
 
-    def new_version(self, created_at: dt.datetime, expires_at: dt.datetime = None) \
-            -> models.Version:
+    def new_version(
+        self, created_at: dt.datetime, expires_at: dt.datetime = None
+    ) -> models.Version:
         """Create a new bundle version."""
         new_version = self.Version(created_at=created_at, expires_at=expires_at)
         return new_version
 
-    def new_file(self, path: str, checksum: str = None, to_archive: bool = False,
-                 tags: List[models.Tag] = None) -> models.File:
+    def new_file(
+        self,
+        path: str,
+        checksum: str = None,
+        to_archive: bool = False,
+        tags: List[models.Tag] = None,
+    ) -> models.File:
         """Create a new file."""
-        new_file = self.File(path=path, checksum=checksum, to_archive=to_archive, tags=tags)
+        new_file = self.File(
+            path=path, checksum=checksum, to_archive=to_archive, tags=tags
+        )
         return new_file
 
     def new_tag(self, name: str, category: str = None) -> models.Tag:

--- a/housekeeper/store/api/add.py
+++ b/housekeeper/store/api/add.py
@@ -23,7 +23,7 @@ class AddHandler(BaseHandler):
         AddHandler.bundle = FindHandler.bundle
         AddHandler.tag = FindHandler.tag
 
-    def add_bundle(self, data: dict) -> models.Bundle:
+    def add_bundle(self, data: dict) -> (models.Bundle, models.Version):
         """Build a new bundle version of files.
 
         The format of the input dict is defined in the `schema` module.


### PR DESCRIPTION
add new tags in CLI

**How to test add new tags in CLI**:
1. install on stage: `bash /home/proj/stage/servers/resources/hasta.scilifelab.se/update-housekeeper-stage.sh feat/add-new-tag`
1. activate stage: `us`
1. run following command: `housekeeper add tag "coffee"`

**Expected outcome**:
`new tag added: coffee (NNNN)` where NNNN is the id of the new tag
Take a screenshot and attach or copy/paste the output.

**Review:**
- [x] code approved by @henrikstranneheim 
- [x] tests executed by @henrikstranneheim 
- [x] "Merge and deploy" approved by @patrikgrenfeldt 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because we added a feature (file needs to be specified with -f and is now optional)