### PR TITLE
Removes some development deps

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -31,6 +31,9 @@ jobs:
       run: |
         pip install -r requirements-dev.txt
         pip install flake8
+        pip install pytest-cov
+        pip install coveralls
+        pip install black
         pip check
 
     - name: Run linters

--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,7 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 pytest-mock = "*"
-pytest-cov = "*"
-black = "*"
-pylint = "*"
-flake8 = "*"
+
 
 [packages]
 alchy = "*"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,3 @@
-pytest>=3.6
-coverage<5
-pytest-cov
-coveralls
+pytest
 pytest-mock
-git-lint
-pylint
-pycodestyle
-yamllint
-docutils
-html-linter
-tidy
-six>=1.12                   # due to astroid 2.3.3
-python-coveralls
-black
-pre-commit
+


### PR DESCRIPTION
This PR removes some unused dependencies from the development dependencies, mainly ones that had to do with the lint checks on travis. 

This is a **patch** since it only removes some unused dev dependencies.