### PR TITLE
Check if file exists before adding. Fix #69

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -48,8 +48,13 @@ def file_cmd(context, tags, archive, bundle_name, path):
         click.echo(click.style(f"unknown bundle: {bundle_name}", fg="red"))
         context.abort()
     version_obj = bundle_obj.versions[0]
+    path = Path(path)
+    if not path.exists():
+        click.echo(click.style(f"File {path} does not exist", fg="red"))
+        context.abort()
+
     new_file = store.new_file(
-        path=str(Path(path).absolute()),
+        path=str(path.absolute()),
         to_archive=archive,
         tags=[
             store.tag(tag_name) if store.tag(tag_name) else store.new_tag(tag_name)

--- a/tests/cli/test_cli_add.py
+++ b/tests/cli/test_cli_add.py
@@ -154,3 +154,20 @@ def test_add_file_existing_bundle(
     assert result.exit_code == 0
     # THEN check that the proper information is displayed
     assert "new file added" in result.output
+
+
+def test_add_non_existing_bundle_file(populated_context, cli_runner, case_id):
+    """Test to add a file that does not exist"""
+    # GIVEN a context with a populated store and a cli runner
+    bundle_name = case_id
+    non_existing_file = "hello.mate"
+
+    # WHEN trying to add a non existing file to a bundle
+    result = cli_runner.invoke(
+        add.file_cmd, [bundle_name, non_existing_file], obj=populated_context
+    )
+
+    # THEN assert it fails
+    assert result.exit_code == 1
+    # THEN check that the proper information is displayed
+    assert f"File {non_existing_file} does not exist" in result.output


### PR DESCRIPTION
This PR adds a check if a file exists when adding from CLI

**How to test**:
1. Tests are automated

**Expected outcome**:
`housekeeper` should abort if trying to add a file that does not exist.

**Review:**
- [x] code approved by HS
- [x] tests executed by GitHub Actions
- [x] "Merge and deploy" approved by @moonso 
Thanks for filling in who performed the code review and the test!

This is patch **version bump**