### PR TITLE
build and publish to pypi

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+ push:
+  tags:
+   - '*'
+
+jobs:
+ build-n-publish:
+  name: Build and publish Python distribution to PyPI
+  runs-on: ubuntu-18.04
+  steps:
+   - name: Check out git repository
+     uses: actions/checkout@v2
+
+   - name: Set up Python 3.7
+     uses: actions/setup-python@v2
+     with:
+      python-version: 3.7
+
+   - name: Install build tools
+     run: >-
+        python -m
+        pip install
+        wheel
+        twine
+        --user
+
+   - name: Build a binary wheel and a source tarball
+     run: >-
+        python
+        setup.py
+        sdist
+        bdist_wheel
+
+   - name: Publish distribution 📦 to PyPI
+     uses: pypa/gh-action-pypi-publish@master
+     with:
+       user: __token__
+       password: ${{ secrets.pypi_password }}

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -1,0 +1,15 @@
+name: "Changelog Reminder"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: dangoslen/changelog-enforcer@v1.1.1
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabel: 'Skip-Changelog'

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
         pip install -r requirements-dev.txt
         pip install flake8
-        pip install black
         pip check
 
     - name: Run linters
@@ -41,8 +40,6 @@ jobs:
         github_token: ${{ secrets.github_token }}
         auto_fix: true
         # Enable linters
-        black: true
-        black_args: "--check"
         # stop the build if there are Python syntax errors or undefined names
         flake8: true
         flake8_args: "housekeeper/ --count --select=E9,F63,F7,F82 --show-source --statistics"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+About changelog [here](https://keepachangelog.com/en/1.0.0/)
+
+Please add a new candidate release at the top after changing the latest one. Feel free to copy paste from the "squash and commit" box that gets generated when creating PRs
+
+## [x.x.x]
+### Added
+
+### Fixed
+
+### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,7 @@ Please add a new candidate release at the top after changing the latest one. Fee
 ### Fixed
 
 ### Changed
+
+## [2.7.5]
+### Added
+- Automatic publish to pypi

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,25 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Based on https://github.com/pypa/sampleproject/blob/master/setup.py."""
+import io
+
 # To use a consistent encoding
-import codecs
 import os
 
 # Always prefer setuptools over distutils
-from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
-import sys
+from setuptools import find_packages, setup
 
-# Shortcut for building/publishing to Pypi
-if sys.argv[-1] == "publish":
-    os.system("python setup.py sdist bdist_wheel upload")
-    sys.exit()
+NAME = "housekeeper"
+DESCRIPTION = "Housekeeper takes care of files"
+AUTHOR = "Robin Andeer"
+EMAIL = "robin.andeer@scilifelab.se"
+URL = "https://github.com/Clinical-Genomics/housekeeper"
+
+HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 def parse_reqs(req_path="./requirements.txt"):
     """Recursively parse requirements from nested pip files."""
     install_requires = []
-    with codecs.open(req_path, "r") as handle:
+    with open(req_path, "r") as handle:
         # remove comments and empty lines
         lines = (
             line.strip() for line in handle if line.strip() and not line.startswith("#")
@@ -35,47 +35,30 @@ def parse_reqs(req_path="./requirements.txt"):
     return install_requires
 
 
-# This is a plug-in for setuptools that will invoke py.test
-# when you run python setup.py test
-class PyTest(TestCommand):
-
-    """Set up the py.test test runner."""
-
-    def finalize_options(self):
-        """Set options for the command line."""
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        """Execute the test runner command."""
-        # Import here, because outside the required eggs aren't loaded yet
-        import pytest
-
-        sys.exit(pytest.main(self.test_args))
-
-
-# Get the long description from the relevant file
-here = os.path.abspath(os.path.dirname(__file__))
-with codecs.open(os.path.join(here, "README.md"), encoding="utf-8") as f:
-    long_description = f.read()
+# Import the README and use it as the long-description.
+# Note: this will only work if 'README.md' is present in your MANIFEST.in file!
+try:
+    with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+        LONG_DESCRIPTION = "\n" + f.read()
+except FileNotFoundError:
+    LONG_DESCRIPTION = DESCRIPTION
 
 
 setup(
-    name="housekeeper",
+    name=NAME,
     # Versions should comply with PEP440. For a discussion on
     # single-sourcing the version across setup.py and the project code,
     # see http://packaging.python.org/en/latest/tutorial.html#version
     version="2.7.4",
-    description=("Housekeeper takes care of files."),
-    long_description=long_description,
+    description=DESCRIPTION,
+    long_description=LONG_DESCRIPTION,
     # What does your project relate to? Separate with spaces.
     keywords="housekeeper development",
-    author="Robin Andeer",
-    author_email="robin.andeer@scilifelab.se",
+    author=AUTHOR,
+    author_email=EMAIL,
     license="MIT",
     # The project's main homepage
-    url="https://github.com/Clinical-Genomics/housekeeper",
+    url=URL,
     packages=find_packages(exclude=("tests*", "docs", "examples")),
     # If there are data files included in your packages that need to be
     # installed, specify them here.
@@ -88,13 +71,11 @@ setup(
     # data_files=[('my_data', ['data/data_file'])],
     # Install requirements loaded from ``requirements.txt``
     install_requires=parse_reqs(),
-    tests_require=["pytest",],
-    cmdclass=dict(test=PyTest,),
     # To provide executable scripts, use entry points in preference to the
     # "scripts" keyword. Entry points provide cross-platform support and
     # allow pip to create the appropriate form of executable for the
     # target platform.
-    entry_points={"console_scripts": ["housekeeper = housekeeper.cli:base",],},
+    entry_points={"console_scripts": ["housekeeper = housekeeper.cli:base"]},
     # See: http://pypi.python.org/pypi?%3Aaction=list_classifiers
     classifiers=[
         # How mature is this project? Common values are:
@@ -107,13 +88,8 @@ setup(
         "Topic :: Software Development",
         # Pick your license as you wish (should match "license" above)
         "License :: OSI Approved :: MIT License",
-        # Specify the Python versions you support here. In particular, ensure
-        # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.6",
         "Environment :: Console",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import find_packages, setup
 NAME = "housekeeper"
 DESCRIPTION = "Housekeeper takes care of files"
 AUTHOR = "Robin Andeer"
-EMAIL = "robin.andeer@scilifelab.se"
+EMAIL = "mans.magnusson@scilifelab.se"
 URL = "https://github.com/Clinical-Genomics/housekeeper"
 
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
# Summary

- This pr adds a workflow to automaticalli publish new releases to PyPI
- It also modifies setup.py tp remove unused code

## This

There has not been releases published to pypi in a long time. When housekeeper is moved out from the production environment to it's own environment we will be able to just `pip install -U housekeeper`.


## Testing

No testing required

### Expected outcome
- [ ] New build is published to pypi
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [x] code approved by @barrystokman 
- [x] "Merge and deploy" approved by MM
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
