### PR TITLE
[On Hold] Do Not Allow Directories To Be Added

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -2,7 +2,9 @@
 from pathlib import Path
 from typing import List
 
+import os
 import click
+
 
 
 @click.group()
@@ -51,6 +53,9 @@ def file_cmd(context, tags, archive, bundle_name, path):
     path = Path(path)
     if not path.exists():
         click.echo(click.style(f"File {path} does not exist", fg="red"))
+        context.abort()
+    if os.path.isdir(path):
+        click.echo(click.style(f"{path} is a directory", fg="red"))
         context.abort()
 
     new_file = store.new_file(

--- a/tests/cli/test_cli_add.py
+++ b/tests/cli/test_cli_add.py
@@ -1,5 +1,6 @@
 """Tests for adding via CLI"""
 
+import os
 from housekeeper.cli import add
 
 # tests adding tags
@@ -171,3 +172,20 @@ def test_add_non_existing_bundle_file(populated_context, cli_runner, case_id):
     assert result.exit_code == 1
     # THEN check that the proper information is displayed
     assert f"File {non_existing_file} does not exist" in result.output
+
+
+def test_add_directory(populated_context, cli_runner, case_id, fixtures_dir):
+    """Test to add a directory, this is not allowed"""
+    # GIVEN a context with a populated store and a cli runner
+    bundle_name = case_id
+
+    # WHEN trying to add a directory to a bundle
+    result = cli_runner.invoke(
+        add.file_cmd, [bundle_name, fixtures_dir.as_posix()], obj=populated_context
+    )
+
+    # THEN assert it fails
+    print(result)
+    assert result.exit_code == 1
+    # THEN check that the proper information is displayed
+    assert f"{fixtures_dir} is a directory" in result.output


### PR DESCRIPTION
# Summary

- This pr solves Housekeeper being able to add directories. 
- No support is given for directories in Housekeeper. Conceptually not decided how to handle. Now trying to add a dir will give an error

## Testing
alt1 `$ pytest test`
alt2 try to add a directory

```
$ housekeeper add file myBumdle my_directory
my_directory is a directory
Aborted!
```

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
