### PR TITLE
Feature squash names 201025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Please add a new candidate release at the top after changing the latest one. Fee
 ## [x.x.x]
 
 ### Added
+- Adds option `--compact` or `-c` to concatenate filenames with subsequent integer name suffixes
 ### Changed
 ### Fixed
 

--- a/housekeeper/cli/get.py
+++ b/housekeeper/cli/get.py
@@ -105,9 +105,10 @@ def version_cmd(context, bundle_name, json, version_id, verbose):
 @click.option("-v", "--version", type=int, help="filter by version of the bundle")
 @click.option("-V", "--verbose", is_flag=True, help="print additional information")
 @click.option("-j", "--json", is_flag=True, help="Output to json format")
+@click.option("-c", "--compact", is_flag=True, help="Print a compact view")
 @click.argument("bundle", required=False)
 @click.pass_context
-def files_cmd(context, tags: List[str], version: int, verbose: bool, bundle: str, json: bool):
+def files_cmd(context, tags: List[str], version: int, verbose: bool, bundle: str, json: bool, compact: bool):
     """Get files from database"""
     store = context.obj["store"]
     file_objs = store.files(bundle=bundle, tags=tags, version=version)
@@ -115,12 +116,11 @@ def files_cmd(context, tags: List[str], version: int, verbose: bool, bundle: str
     result = []
     for file_obj in file_objs:
         result.append(template.dump(file_obj))
-
     if json:
         click.echo(jsonlib.dumps(result))
         return
     console = Console()
-    console.print(get_files_table(result, verbose=verbose))
+    console.print(get_files_table(result, verbose=verbose, compact=compact))
 
 
 @get.command("tag")

--- a/housekeeper/cli/get.py
+++ b/housekeeper/cli/get.py
@@ -23,8 +23,9 @@ def get():
 @click.option("-i", "--bundle-id", type=int, help="Search for a bundle with bundle id")
 @click.option("-j", "--json", is_flag=True, help="Output to json format")
 @click.option("-v", "--verbose", is_flag=True, help="List files from latest version")
+@click.option("-c", "--compact", is_flag=True, help="print compact filenames IFF verobe flag present")
 @click.pass_context
-def bundle_cmd(context, bundle_name, bundle_id, json, verbose):
+def bundle_cmd(context, bundle_name, bundle_id, json, verbose, compact):
     """Get bundle information from database"""
     store = context.obj["store"]
     bundle_objs = store.bundles()
@@ -50,7 +51,7 @@ def bundle_cmd(context, bundle_name, bundle_id, json, verbose):
                 LOG.info("No versions found for bundle %s", bundle.name)
                 return
             version_obj = bundle.versions[0]
-            context.invoke(version_cmd, version_id=version_obj.id, verbose=True)
+            context.invoke(version_cmd, version_id=version_obj.id, verbose=True, compact=compact)
 
 
 @get.command("version")
@@ -58,8 +59,9 @@ def bundle_cmd(context, bundle_name, bundle_id, json, verbose):
 @click.option("-i", "--version-id", type=int, help="Fetch a specific version")
 @click.option("-j", "--json", is_flag=True, help="Output to json format")
 @click.option("-v", "--verbose", is_flag=True, help="print additional information")
+@click.option("-c", "--compact", is_flag=True, help="print compact filenames IFF verobe flag present")
 @click.pass_context
-def version_cmd(context, bundle_name, json, version_id, verbose):
+def version_cmd(context, bundle_name, json, version_id, verbose, compact):
     """Get versions from database"""
     store = context.obj["store"]
     if not (bundle_name or version_id):
@@ -97,7 +99,7 @@ def version_cmd(context, bundle_name, json, version_id, verbose):
         return
 
     for version_obj in version_objs:
-        context.invoke(files_cmd, version=version_obj.id, verbose=True)
+        context.invoke(files_cmd, version=version_obj.id, verbose=True, compact=compact)
 
 
 @get.command("file")
@@ -105,7 +107,7 @@ def version_cmd(context, bundle_name, json, version_id, verbose):
 @click.option("-v", "--version", type=int, help="filter by version of the bundle")
 @click.option("-V", "--verbose", is_flag=True, help="print additional information")
 @click.option("-j", "--json", is_flag=True, help="Output to json format")
-@click.option("-c", "--compact", is_flag=True, help="Print a compact view")
+@click.option("-c", "--compact", is_flag=True, help="print compact filenames")
 @click.argument("bundle", required=False)
 @click.pass_context
 def files_cmd(context, tags: List[str], version: int, verbose: bool, bundle: str, json: bool, compact: bool):

--- a/housekeeper/cli/tables.py
+++ b/housekeeper/cli/tables.py
@@ -44,7 +44,6 @@ def get_files_table(rows: List[dict], verbose=False, compact=False) -> Table:
             table.add_row(str(file_obj["id"]), f"[yellow]{file_name}[/yellow]", file_tags)
         else:
             table.add_row(str(file_obj["id"]), f"[blue]{file_name}[/blue]", file_tags)
-
     return table
 
 
@@ -136,6 +135,7 @@ def squash_names(list_of_files: List[dict]) -> List[dict]:
                     previous_file + "[" + squash[0] + "-" + squash[-1] + "]" + previous_suffix
                 )
                 previous_hkjson["path"] = squashed_path
+                previous_hkjson["full_path"] = squashed_path
                 previous_hkjson["tags"] = remove_duplicates(sorted(tag_list, key=lambda i: i["id"]))
                 previous_hkjson["id"] = "-"
                 list_of_squashed.append(previous_hkjson)
@@ -150,12 +150,10 @@ def squash_names(list_of_files: List[dict]) -> List[dict]:
 
 def remove_duplicates(tag_list: List[dict]) -> List[dict]:
     """Remove duoplicate elements from `tag_list`"""
-    print("tag_list: {}".format(tag_list))
     no_duplicates = []
     for i in tag_list:
         if i not in no_duplicates:
             no_duplicates.append(i)
-    print("no_duplicates: {}".format(no_duplicates))
     return no_duplicates
 
 

--- a/housekeeper/cli/tables.py
+++ b/housekeeper/cli/tables.py
@@ -90,12 +90,6 @@ def get_versions_table(rows: List[dict]) -> Table:
         )
     return table
 
-    """If subsequent elements (filenames) in 'list_of_files' end in an integer- And that integer is
-    following the previous- those are squashed when displayed.
-    Example:
-
-        ["asdf1.txt", "asdf2.txt"] becomes asdf[1-2].txt'
-    """
 
 def squash_names(list_of_files):
     """If subsequent elements (filenames) in 'list_of_files' end in an integer- And that integer is

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -92,4 +92,3 @@ def fixture_bundle_data_subsequent(
         ],
     }
     return data
-

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,9 +1,11 @@
 """Fixtures for CLI tests"""
-
+import datetime
 import pytest
 from click.testing import CliRunner
-
+from copy import deepcopy
+from pathlib import Path
 from housekeeper.store import Store
+from tests.helper_functions import Helpers
 
 
 @pytest.yield_fixture(scope="function", name="store")
@@ -42,3 +44,52 @@ def fixture_populated_context(db_uri, project_dir, populated_store):
         "store": populated_store,
     }
     return _ctx
+
+
+
+@pytest.yield_fixture(scope="function", name="populated_store_subsequent")
+def fixture_populated_store_subsequent(store: Store, bundle_data_subsequent: dict, helpers: Helpers) -> Store:
+    """Returns a populated store"""
+    helpers.add_bundle(store, bundle_data_subsequent)
+    return store
+
+
+@pytest.fixture(scope="function", name="populated_context_subsequent")
+def fixture_populated_context_subsequent(db_uri, project_dir, populated_store_subsequent):
+    """Return a context with initialized database with some data"""
+    _ctx = {
+        "database": db_uri,
+        "root": project_dir,
+        "store": populated_store_subsequent,
+    }
+    return _ctx
+
+
+@pytest.fixture(scope="function", name="bundle_data_subsequent")
+def fixture_bundle_data_subsequent(
+        case_id: str, family_data: dict, family2_data: dict, family3_data:dict, timestamp: datetime.datetime
+) -> dict:
+    """Return a dummy bundle"""
+    data = {
+        "name": case_id,
+        "created_at": timestamp,
+        "files": [
+            {
+                "path": str(family_data["file"]),
+                "archive": False,
+                "tags": family_data["tags"],
+            },
+            {
+                "path": str(family2_data["file"]),
+                "archive": False,
+                "tags": family2_data["tags"],
+            },
+            {
+                "path": str(family3_data["file"]),
+                "archive": True,
+                "tags": family3_data["tags"],
+            }
+        ],
+    }
+    return data
+

--- a/tests/cli/get/test_get_files.py
+++ b/tests/cli/get/test_get_files.py
@@ -122,23 +122,13 @@ def test_get_files_rare_tag(populated_context, cli_runner, helpers, family_tag_n
 
 def test_get_files_compact(populated_context_subsequent, cli_runner, family_tag_name, helpers):
     """Test to get all files from a populated store in human friendly format, subsequent names concatenated"""
-    # GIVEN a context with a populated store and a cli runner
-    # GIVEN a store with some files
-    store = populated_context_subsequent["store"]
-    nr_files = helpers.count_iterable(store.files())
+    # GIVEN an example result file list
+    file_list = [{'path': 'family.vcf', 'full_path': 'tests/family.vcf', 'tags': [], 'id': 7},
+                 {'path': 'family.2.vcf', 'full_path': '/tests/family.2.vcf', 'tags': [], 'id': 8},
+                 {'path': 'family.3.vcf', 'full_path': '/tests/family.3.vcf', 'tags': [], 'id': 9}]
 
     # WHEN calling `squash_names` on list of files
-    vcf_list = [store.files()[0], store.files()[1], store.files()[2]]
-    squashed = squash_names(vcf_list)
-
-    # WHEN fetching all files in compact view
-    result = cli_runner.invoke(files_cmd, ["--compact"], obj=populated_context_subsequent)
+    squashed = squash_names(file_list)
 
     # THEN assert that the file names displayed are squashed
-    squashed_names = Path(squashed[1]["path"]).name
-    assert squashed_names in result.output
-    # THEN assert fewer lines than database entries are displayed
-    assert len(squashed) < nr_files
-
-
-
+    assert len(squashed) < len(file_list)

--- a/tests/cli/get/test_get_files.py
+++ b/tests/cli/get/test_get_files.py
@@ -123,7 +123,7 @@ def test_get_files_rare_tag(populated_context, cli_runner, helpers, family_tag_n
 def test_get_files_compact(populated_context_subsequent, cli_runner, family_tag_name, helpers):
     """Test to get all files from a populated store in human friendly format, subsequent names concatenated"""
     # GIVEN a context with a populated store and a cli runner
-    # GIVEN a store with some files 
+    # GIVEN a store with some files
     store = populated_context_subsequent["store"]
     nr_files = helpers.count_iterable(store.files())
 
@@ -140,5 +140,5 @@ def test_get_files_compact(populated_context_subsequent, cli_runner, family_tag_
     # THEN assert fewer lines than database entries are displayed
     assert len(squashed) < nr_files
 
-    
+
 

--- a/tests/cli/get/test_get_files.py
+++ b/tests/cli/get/test_get_files.py
@@ -1,7 +1,7 @@
 """Tests for cli get file functionality"""
 from pathlib import Path
 from housekeeper.cli.get import files_cmd
-from housekeeper.cli.tables import squash_names
+from housekeeper.cli.tables import squash_names, _get_suffix
 
 
 def test_get_files_no_files(base_context, cli_runner, helpers):
@@ -132,3 +132,24 @@ def test_get_files_compact(populated_context_subsequent, cli_runner, family_tag_
 
     # THEN assert that the file names displayed are squashed
     assert len(squashed) < len(file_list)
+
+
+def test_get_suffix():
+    # GIVEN
+    dont_split_name1 = "asdf2.asdf.vcf"
+    dont_split_name2 = "1123"
+    dont_split_name3 = "asdf.vcf"
+    dont_split_name4 = "asdf_2.asdf.vcf"
+
+    split_name1 = "asdf1.png"
+    split_name2 = "asdf8A8_7777_asdf_8.png"
+
+    # THEN assert filename parsing *does not* split name into (prefix, integer, suffix)
+    assert (dont_split_name1, '', '') == _get_suffix(dont_split_name1)
+    assert (dont_split_name2, '', '') == _get_suffix(dont_split_name2)
+    assert (dont_split_name3, '', '') == _get_suffix(dont_split_name3)
+    assert (dont_split_name4, '', '') == _get_suffix(dont_split_name4)
+
+    # THEN assert filename parsing *does* split name into (prefix, integer, suffix)
+    assert (split_name1, '', '') != _get_suffix(split_name1)
+    assert (split_name2, '', '') != _get_suffix(split_name2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,11 @@ def fixture_family2_data(family_tag_names: List[str], second_family_vcf: Path) -
     """Return file and tags for sample"""
     return {"tags": family_tag_names, "file": second_family_vcf}
 
+@pytest.fixture(scope="function", name="family3_data")
+def fixture_family3_data(family_tag_names: List[str], third_family_vcf: Path) -> dict:
+    """Return file and tags for sample"""
+    return {"tags": family_tag_names, "file": third_family_vcf}
+
 
 @pytest.fixture(scope="function", name="timestamp_string")
 def fixture_timestamp_string() -> str:
@@ -318,6 +323,12 @@ def fixture_second_sample_vcf(vcf_dir: Path) -> Path:
 def fixture_second_family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file"""
     return vcf_dir / "family.2.vcf"
+
+
+@pytest.fixture(scope="function", name="third_family_vcf")
+def fixture_third_family_vcf(vcf_dir: Path) -> Path:
+    """Return the path to a vcf file"""
+    return vcf_dir / "family.3.vcf"
 
 
 @pytest.fixture(scope="function", name="checksum_file")


### PR DESCRIPTION
# Summary

- This pr solves issues of very many files displayed causing annoyance.
- And adresses that by adding an option `--compact`.

## This

For example a bundle view like this:
```
asdf                 
test_upd.sites_1.png 
test_upd.sites_2.png 
test_upd.sites_3.png 
test_upd.sites_4.png
```

Will be displayed as:
```
 asdf                                                                                                               
 test_upd.sites_[1-4].png
```

Filenames ending in subsequent integers will be concatenated. Iff the files are listed in increasing order without interruption.

## Testing
One Pytest is added for checking output. 

Test on large bundles. 

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-housekeeper-stage.sh [THIS-BRANCH-NAME]`

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MINOR** - when you add functionality in a backwards compatible manner