### PR TITLE
(fix) Publish to pypi on release action

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,9 +1,9 @@
 name: Publish to PyPI and Docker
 
 on:
- push:
-  tags:
-   - '*'
+  release:
+    types:
+      - created
 
 jobs:
  build-n-publish:


### PR DESCRIPTION
## Description

### Changed

- The deployment instructions in github actions so that the release is done to pypi when there is a new version


## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b YOURBRANCH```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ x ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
