### PR TITLE
Remove alchy

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -66,9 +66,10 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str):
     except FileNotFoundError as err:
         LOG.warning("File %s does not exist", err)
         raise click.Abort
-    store.add_commit(new_bundle)
+    store.session.add(new_bundle)
     new_version.bundle: Bundle = new_bundle
-    store.add_commit(new_version)
+    store.session.add(new_version)
+    store.session.commit()
     LOG.info("new bundle added: %s (%s)", new_bundle.name, new_bundle.id)
 
 
@@ -78,7 +79,9 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str):
 @click.option("-j", "--json", help="json formatted input")
 @click.argument("path", required=False)
 @click.pass_context
-def file_cmd(context: click.Context, tags: List[str], bundle_name: str, json: str, path: str):
+def file_cmd(
+    context: click.Context, tags: List[str], bundle_name: str, json: str, path: str
+):
     """Add a file to the latest version of a bundle."""
     LOG.info("Running add file")
     store: Store = context.obj["store"]
@@ -104,7 +107,8 @@ def file_cmd(context: click.Context, tags: List[str], bundle_name: str, json: st
     tags = data.get("tags", tags)
 
     new_file = store.add_file(file_path=file_path, bundle=bundle, tags=tags)
-    store.add_commit(new_file)
+    store.session.add(new_file)
+    store.session.commit()
     LOG.info("new file added: %s (%s)", new_file.path, new_file.id)
 
 
@@ -116,7 +120,7 @@ def file_cmd(context: click.Context, tags: List[str], bundle_name: str, json: st
 def version_cmd(context: click.Context, bundle_name: str, created_at: str, json: str):
     """Add a new version to a bundle."""
     LOG.info("Running add version")
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
 
     validate_args(arg=bundle_name, json=json, arg_name="bundle_name")
 
@@ -140,7 +144,8 @@ def version_cmd(context: click.Context, bundle_name: str, created_at: str, json:
         LOG.warning("Seems like version already exists for the bundle")
         raise click.Abort
 
-    store.add_commit(new_version)
+    store.session.add(new_version)
+    store.session.commit()
     LOG.info("new version (%s) added to bundle %s", new_version.id, bundle.name)
 
 
@@ -171,7 +176,8 @@ def tag_cmd(context: click.Context, tags: List[str], file_id: int):
         if not tag:
             LOG.info("%s: tag created", tag_name)
             tag: Tag = store.new_tag(tag_name)
-            store.add_commit(tag)
+            store.session.add(tag)
+            store.session.commit()
 
         if not file:
             continue

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -188,7 +188,7 @@ def tag_cmd(context: click.Context, tags: List[str], file_id: int):
 
         file.tags.append(tag)
 
-    store.commit()
+    store.session.commit()
 
     if not file:
         return

--- a/housekeeper/cli/core.py
+++ b/housekeeper/cli/core.py
@@ -21,7 +21,13 @@ LOG = logging.getLogger(__name__)
 @click.option("-l", "--log-level", default="INFO")
 @click.version_option(housekeeper.__version__, prog_name=housekeeper.__title__)
 @click.pass_context
-def base(context: click.Context, config: click.File, database: Optional[str], root: Optional[str], log_level: str):
+def base(
+    context: click.Context,
+    config: click.File,
+    database: Optional[str],
+    root: Optional[str],
+    log_level: str,
+):
     """Housekeeper - Access your files!"""
     coloredlogs.install(level=log_level)
     config_values = {}

--- a/housekeeper/cli/delete.py
+++ b/housekeeper/cli/delete.py
@@ -39,7 +39,7 @@ def bundle_cmd(context, yes, bundle_name):
         raise click.Abort
 
     bundle.delete()
-    store.commit()
+    store.session.commit()
     LOG.info("Bundle deleted: %s", bundle.name)
 
 
@@ -90,7 +90,7 @@ def version_cmd(context, bundle_name, version_id, yes):
         shutil.rmtree(version_obj.full_path, ignore_errors=True)
 
     version_obj.delete()
-    store.commit()
+    store.session.commit()
     LOG.info("version deleted: %s", version_obj.full_path)
 
 
@@ -184,7 +184,7 @@ def delete_file(file: File, store: Store):
     if file_should_be_unlinked(file):
         file_path.unlink()
     file.delete()
-    store.commit()
+    store.session.commit()
     LOG.info(f"{file.full_path} deleted")
 
 
@@ -224,5 +224,5 @@ def file_cmd(context, yes, file_id):
             Path(file.full_path).unlink()
 
         file.delete()
-        store.commit()
+        store.session.commit()
         LOG.info("file deleted")

--- a/housekeeper/cli/delete.py
+++ b/housekeeper/cli/delete.py
@@ -24,7 +24,7 @@ def delete():
 @click.pass_context
 def bundle_cmd(context, yes, bundle_name):
     """Delete a empty bundle, that is a bundle without versions."""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     bundle = store.get_bundle_by_name(bundle_name=bundle_name)
     if bundle is None:
         LOG.warning("bundle %s not found", bundle_name)
@@ -38,7 +38,7 @@ def bundle_cmd(context, yes, bundle_name):
     if not (yes or click.confirm(question)):
         raise click.Abort
 
-    bundle.delete()
+    store.session.delete(bundle)
     store.session.commit()
     LOG.info("Bundle deleted: %s", bundle.name)
 
@@ -50,7 +50,7 @@ def bundle_cmd(context, yes, bundle_name):
 @click.pass_context
 def version_cmd(context, bundle_name, version_id, yes):
     """Delete a version from database"""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     if not (bundle_name or version_id):
         LOG.info("Please select a bundle or a version")
         raise click.Abort
@@ -89,7 +89,7 @@ def version_cmd(context, bundle_name, version_id, yes):
     if version_obj.included_at:
         shutil.rmtree(version_obj.full_path, ignore_errors=True)
 
-    version_obj.delete()
+    store.session.delete(version_obj)
     store.session.commit()
     LOG.info("version deleted: %s", version_obj.full_path)
 
@@ -116,7 +116,7 @@ def files_cmd(
 
     validate_delete_options(tag=tag, bundle_name=bundle_name)
     before_date = parse_date(before) if before else None
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
 
     if bundle_name:
         validate_bundle_exists(store=store, bundle_name=bundle_name)
@@ -183,7 +183,8 @@ def delete_file(file: File, store: Store):
     file_path = Path(file.full_path)
     if file_should_be_unlinked(file):
         file_path.unlink()
-    file.delete()
+
+    store.session.delete(file)
     store.session.commit()
     LOG.info(f"{file.full_path} deleted")
 
@@ -208,7 +209,7 @@ def parse_date(date: str):
 @click.pass_context
 def file_cmd(context, yes, file_id):
     """Delete a file."""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     file = store.get_file_by_id(file_id=file_id)
     if not file:
         LOG.info("file not found")
@@ -223,6 +224,6 @@ def file_cmd(context, yes, file_id):
         if file.is_included and Path(file.full_path).exists():
             Path(file.full_path).unlink()
 
-        file.delete()
+        store.session.delete(file)
         store.session.commit()
         LOG.info("file deleted")

--- a/housekeeper/cli/get.py
+++ b/housekeeper/cli/get.py
@@ -37,7 +37,7 @@ def get():
 @click.pass_context
 def bundle_cmd(context, bundle_name, bundle_id, json, verbose, compact):
     """Get bundle information from database"""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     bundles = store.bundles()
 
     if bundle_name:
@@ -86,7 +86,7 @@ def bundle_cmd(context, bundle_name, bundle_id, json, verbose, compact):
 @click.pass_context
 def version_cmd(context, bundle_name, json, version_id, verbose, compact):
     """Get versions from database"""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     if not (bundle_name or version_id):
         LOG.info("Please select a bundle or a version")
         return
@@ -147,7 +147,7 @@ def files_cmd(
     compact: bool,
 ):
     """Get files from database"""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     file_objs = store.get_files(
         bundle_name=bundle, tag_names=tag_names, version_id=version_id
     )
@@ -168,7 +168,7 @@ def files_cmd(
 @click.pass_context
 def tag_cmd(context, json, name):
     """Get the tags from database"""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     LOG.info("Fetch tags")
     tag_objs = store.get_tags()
     template = schema.TagSchema()

--- a/housekeeper/cli/get.py
+++ b/housekeeper/cli/get.py
@@ -7,6 +7,8 @@ import click
 from rich.console import Console
 
 from housekeeper.store.api import schema
+from housekeeper.store.api.core import Store
+from housekeeper.store.models import Version
 
 from .tables import (
     get_bundles_table,
@@ -98,7 +100,7 @@ def version_cmd(context, bundle_name, json, version_id, verbose, compact):
         version_objs = bundle.versions
 
     if version_id:
-        version = store.Version.get(version_id)
+        version: Version = store.get_version_by_id(version_id=version_id)
         if not version:
             LOG.warning("Could not find version %s", version_id)
             raise click.Abort

--- a/housekeeper/cli/include.py
+++ b/housekeeper/cli/include.py
@@ -6,6 +6,7 @@ import click
 
 from housekeeper.exc import VersionIncludedError
 from housekeeper.include import include_version
+from housekeeper.store.api.core import Store
 
 LOG = logging.getLogger(__name__)
 
@@ -27,7 +28,7 @@ def include(context: click.Context, bundle_name: str, version_id: int):
 
     if version_id:
         LOG.info("Use version %s", version_id)
-        version_obj = store.Version.get(version_id)
+        version_obj = store.get_version_by_id(version_id=version_id)
         if version_obj is None:
             LOG.warning("version not found")
             raise click.Abort

--- a/housekeeper/cli/include.py
+++ b/housekeeper/cli/include.py
@@ -52,5 +52,5 @@ def include(context: click.Context, bundle_name: str, version_id: int):
         raise click.Abort
 
     version_obj.included_at = dt.datetime.now()
-    store.commit()
+    store.session.commit()
     click.echo(click.style("included all files!", fg="green"))

--- a/housekeeper/cli/include.py
+++ b/housekeeper/cli/include.py
@@ -20,7 +20,7 @@ def include(context: click.Context, bundle_name: str, version_id: int):
     Use bundle name if you simply want to include the latest version.
     """
     LOG.info("Running include")
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     if not (version_id or bundle_name):
         LOG.warning("Please use bundle name or version-id")
         raise click.Abort

--- a/housekeeper/cli/init.py
+++ b/housekeeper/cli/init.py
@@ -1,7 +1,7 @@
 """Initialise HK db from CLI"""
 import logging
-
 import click
+from housekeeper.store.api.core import Store
 
 LOG = logging.getLogger(__name__)
 

--- a/housekeeper/cli/init.py
+++ b/housekeeper/cli/init.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger(__name__)
 @click.pass_context
 def init(context, reset, force):
     """Setup the database."""
-    store = context.obj["store"]
+    store: Store = context.obj["store"]
     existing_tables = store.engine.table_names()
     if force or reset:
         if existing_tables and not force:

--- a/housekeeper/store/api/add.py
+++ b/housekeeper/store/api/add.py
@@ -4,6 +4,7 @@ import datetime as dt
 import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
+from sqlalchemy.orm import Session
 
 from housekeeper.store import models
 from housekeeper.store.api.base import BaseHandler
@@ -15,8 +16,8 @@ LOG = logging.getLogger(__name__)
 class AddHandler(BaseHandler):
     """Handles adding things to the store"""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, session: Session):
+        super().__init__(session=session)
         AddHandler.version = FindHandler.version
         AddHandler.get_bundle_by_name = FindHandler.get_bundle_by_name
         AddHandler.get_tag = FindHandler.get_tag

--- a/housekeeper/store/api/add.py
+++ b/housekeeper/store/api/add.py
@@ -18,7 +18,6 @@ class AddHandler(BaseHandler):
 
     def __init__(self, session: Session):
         super().__init__(session=session)
-        AddHandler.version = FindHandler.version
         AddHandler.get_bundle_by_name = FindHandler.get_bundle_by_name
         AddHandler.get_tag = FindHandler.get_tag
 

--- a/housekeeper/store/api/add.py
+++ b/housekeeper/store/api/add.py
@@ -20,6 +20,9 @@ class AddHandler(BaseHandler):
         super().__init__(session=session)
         AddHandler.get_bundle_by_name = FindHandler.get_bundle_by_name
         AddHandler.get_tag = FindHandler.get_tag
+        AddHandler.get_version_by_date_and_bundle_name = (
+            FindHandler.get_version_by_date_and_bundle_name
+        )
 
     def new_bundle(self, name: str, created_at: dt.datetime = None) -> models.Bundle:
         """Create a new file bundle."""

--- a/housekeeper/store/api/base.py
+++ b/housekeeper/store/api/base.py
@@ -1,22 +1,24 @@
 """This module defines a BaseHandler class holding different models"""
 
 from typing import Type
-from housekeeper.store.models import Bundle, File, Version, Tag
-from alchy import ModelBase, Query
+from housekeeper.store.models import Bundle, File, Version, Tag, Model
+from sqlalchemy.orm import Query, Session
 
 
 class BaseHandler:
     """This is a base class holding different models"""
 
-    Bundle: Type[ModelBase] = Bundle
-    Version: Type[ModelBase] = Version
-    File: Type[ModelBase] = File
-    Tag: Type[ModelBase] = Tag
+    Bundle: Type[Model] = Bundle
+    Version: Type[Model] = Version
+    File: Type[Model] = File
+    Tag: Type[Model] = Tag
 
-    @staticmethod
-    def _get_query(table: Type[ModelBase]) -> Query:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def _get_query(self, table: Type[Model]) -> Query:
         """Return a query for the given table."""
-        return table.query
+        return self.session.query(table)
 
     def _get_join_version_bundle_query(self) -> Query:
         """Return version bundle query."""

--- a/housekeeper/store/api/base.py
+++ b/housekeeper/store/api/base.py
@@ -22,11 +22,11 @@ class BaseHandler:
 
     def _get_join_version_bundle_query(self) -> Query:
         """Return version bundle query."""
-        return self.Version.query.join(Version.bundle)
+        return self._get_query(table=Version).join(Version.bundle)
 
     def _get_join_file_tag_query(self) -> Query:
         """Return file tag query."""
-        return self.File.query.join(File.tags)
+        return self._get_query(table=File).join(File.tags)
 
     def _get_join_version_query(self, query: Query):
         return query.join(Version)

--- a/housekeeper/store/api/core.py
+++ b/housekeeper/store/api/core.py
@@ -36,7 +36,6 @@ class Store(CoreHandler):
         self.engine = create_engine(uri)
         session_factory = sessionmaker(bind=self.engine)
         self.session = scoped_session(session_factory)
-        self.Model = Model
 
         LOG.debug("Initializing Store")
         self.File.app_root = Path(root)

--- a/housekeeper/store/api/core.py
+++ b/housekeeper/store/api/core.py
@@ -43,3 +43,11 @@ class Store(CoreHandler):
         self.Version.app_root = Path(root)
 
         super().__init__(self.session)
+
+    def create_all(self):
+        """Create all tables in the database."""
+        Model.metadata.create_all(bind=self.session.get_bind())
+
+    def drop_all(self):
+        """Drop all tables in the database."""
+        Model.metadata.drop_all(bind=self.session.get_bind())

--- a/housekeeper/store/api/find.py
+++ b/housekeeper/store/api/find.py
@@ -4,9 +4,8 @@ This module handles finding things in the store/database
 import datetime as dt
 import logging
 from pathlib import Path
-from typing import List, Optional, Set
-
-from sqlalchemy.orm import Query
+from typing import List
+from sqlalchemy.orm import Query, Session
 
 from housekeeper.store.filters.bundle_filters import BundleFilters, apply_bundle_filter
 from housekeeper.store.filters.file_filters import FileFilter, apply_file_filter
@@ -32,6 +31,9 @@ LOG = logging.getLogger(__name__)
 
 class FindHandler(BaseHandler):
     """Handler for searching the database"""
+
+    def __init__(self, session: Session):
+        super().__init__(session=session)
 
     def bundles(self):
         """Fetch bundles."""
@@ -88,10 +90,6 @@ class FindHandler(BaseHandler):
         """Return all tags from the database."""
         LOG.info("Fetching all tags")
         return self._get_query(table=Tag)
-
-    def _get_tag_query(self) -> Query:
-        """Return a tag query."""
-        return self.Tag.query
 
     def get_file_by_id(self, file_id: int):
         """Get a file by record id."""

--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -3,10 +3,10 @@
 import datetime as dt
 from pathlib import Path
 
-import alchy
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint, orm, types
 
-Model = alchy.make_declarative_base(Base=alchy.ModelBase)
+Model = declarative_base()
 
 
 file_tag_link = Table(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-Alchy
 Click<7
 coloredlogs
 marshmallow

--- a/tests/cli/add/test_cli_add_bundle.py
+++ b/tests/cli/add/test_cli_add_bundle.py
@@ -6,15 +6,17 @@ from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli.add import bundle_cmd
+from housekeeper.store.api.core import Store
+from housekeeper.store.models import Bundle
 
 
 def test_add_existing_bundle(populated_context: Context, cli_runner: CliRunner, caplog):
     """Test to add a bundle that exists"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a existing bundle
-    bundle_obj = store.Bundle.query.first()
+    bundle_obj = store._get_query(table=Bundle).first()
     assert bundle_obj
     bundle_name = bundle_obj.name
 
@@ -27,7 +29,9 @@ def test_add_existing_bundle(populated_context: Context, cli_runner: CliRunner, 
     assert "already exists" in caplog.text
 
 
-def test_add_simple_bundle(base_context: Context, cli_runner: CliRunner, case_id: str, caplog):
+def test_add_simple_bundle(
+    base_context: Context, cli_runner: CliRunner, case_id: str, caplog
+):
     """Test to add a new bundle by only specifying bundle name"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a empty store and a cli runner
@@ -70,7 +74,9 @@ def test_add_bundle_json_and_bundle_name(
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a empty store, a cli runner and a bundle in json format
     # WHEN trying to add a bundle with both json and bundle_name as input
-    result = cli_runner.invoke(bundle_cmd, [case_id, "--json", bundle_data_json], obj=base_context)
+    result = cli_runner.invoke(
+        bundle_cmd, [case_id, "--json", bundle_data_json], obj=base_context
+    )
 
     # THEN assert the call failed
     assert result.exit_code == 1
@@ -85,7 +91,9 @@ def test_add_bundle_json(
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a empty store, a cli runner and a bundle in json format
     # WHEN trying to add a bundle
-    result = cli_runner.invoke(bundle_cmd, ["--json", bundle_data_json], obj=base_context)
+    result = cli_runner.invoke(
+        bundle_cmd, ["--json", bundle_data_json], obj=base_context
+    )
 
     # THEN assert it succeded
     assert result.exit_code == 0
@@ -106,7 +114,9 @@ def test_add_bundle_json_no_files(
     bundle_data_json = json.dumps(bundle_data)
 
     # WHEN trying to add a bundle
-    result = cli_runner.invoke(bundle_cmd, ["--json", bundle_data_json], obj=base_context)
+    result = cli_runner.invoke(
+        bundle_cmd, ["--json", bundle_data_json], obj=base_context
+    )
 
     # THEN assert it succeded
     assert result.exit_code == 0
@@ -130,7 +140,9 @@ def test_add_bundle_non_existing_file(
     bundle_data_json = json.dumps(bundle_data)
 
     # WHEN trying to add a bundle
-    result = cli_runner.invoke(bundle_cmd, ["--json", bundle_data_json], obj=base_context)
+    result = cli_runner.invoke(
+        bundle_cmd, ["--json", bundle_data_json], obj=base_context
+    )
 
     # THEN assert it succeded
     assert result.exit_code == 1
@@ -151,7 +163,9 @@ def test_add_bundle_json_missing_data(
     bundle_data_json = json.dumps(bundle_data)
 
     # WHEN trying to add a bundle
-    result = cli_runner.invoke(bundle_cmd, ["--json", bundle_data_json], obj=base_context)
+    result = cli_runner.invoke(
+        bundle_cmd, ["--json", bundle_data_json], obj=base_context
+    )
 
     # THEN assert it succeded
     assert result.exit_code == 1

--- a/tests/cli/add/test_cli_add_tags.py
+++ b/tests/cli/add/test_cli_add_tags.py
@@ -2,6 +2,7 @@
 import logging
 
 from housekeeper.cli.add import tag_cmd
+from housekeeper.store.api.core import Store
 
 
 def test_add_tags_no_args(populated_context, cli_runner, caplog):
@@ -43,7 +44,7 @@ def test_add_existing_tag_existing_file(populated_context, cli_runner, caplog):
     """Test to add a existing tag to a file that exists"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store, and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a existing file id
     file_id = 1
     file_obj = store.File.get(file_id)
@@ -51,7 +52,9 @@ def test_add_existing_tag_existing_file(populated_context, cli_runner, caplog):
     tag = file_obj.tags[0].name
 
     # WHEN trying to add the existing tag to the file
-    result = cli_runner.invoke(tag_cmd, [tag, "-f", str(file_id)], obj=populated_context)
+    result = cli_runner.invoke(
+        tag_cmd, [tag, "-f", str(file_id)], obj=populated_context
+    )
     # THEN assert it has a non zero exit status
     assert result.exit_code == 0
     # THEN check that it communicates that the tag existed
@@ -62,7 +65,7 @@ def test_add_tag_existing_file(populated_context, cli_runner, caplog):
     """Test to add a non existing tag to a file that exists"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store, and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a existing file id
     file_id = 1
     file_obj = store.File.get(file_id)
@@ -71,7 +74,9 @@ def test_add_tag_existing_file(populated_context, cli_runner, caplog):
     tag = "new-tag"
 
     # WHEN trying to add a tag to the existing file
-    result = cli_runner.invoke(tag_cmd, [tag, "-f", str(file_id)], obj=populated_context)
+    result = cli_runner.invoke(
+        tag_cmd, [tag, "-f", str(file_id)], obj=populated_context
+    )
     # THEN assert it has a zero exit status
     assert result.exit_code == 0
     # THEN check that the tag is displayed in the output
@@ -82,7 +87,7 @@ def test_add_tag_non_existing_file(populated_context, cli_runner, caplog):
     """Test to add a tag to a file that not exist"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a non existing file id
     missing_file_id = 42
     file_obj = store.File.get(missing_file_id)

--- a/tests/cli/add/test_cli_add_tags.py
+++ b/tests/cli/add/test_cli_add_tags.py
@@ -3,6 +3,7 @@ import logging
 
 from housekeeper.cli.add import tag_cmd
 from housekeeper.store.api.core import Store
+from housekeeper.store.models import File
 
 
 def test_add_tags_no_args(populated_context, cli_runner, caplog):
@@ -47,7 +48,7 @@ def test_add_existing_tag_existing_file(populated_context, cli_runner, caplog):
     store: Store = populated_context["store"]
     # GIVEN a existing file id
     file_id = 1
-    file_obj = store.File.get(file_id)
+    file_obj: File = store.get_file_by_id(file_id=file_id)
     # GIVEN that the new tag already exists for the file
     tag = file_obj.tags[0].name
 
@@ -68,7 +69,7 @@ def test_add_tag_existing_file(populated_context, cli_runner, caplog):
     store: Store = populated_context["store"]
     # GIVEN a existing file id
     file_id = 1
-    file_obj = store.File.get(file_id)
+    file_obj: File = store.get_file_by_id(file_id=file_id)
     assert file_obj
     # GIVEN a new tag
     tag = "new-tag"
@@ -90,7 +91,7 @@ def test_add_tag_non_existing_file(populated_context, cli_runner, caplog):
     store: Store = populated_context["store"]
     # GIVEN a non existing file id
     missing_file_id = 42
-    file_obj = store.File.get(missing_file_id)
+    file_obj = store.get_file_by_id(file_id=missing_file_id)
     assert not file_obj
 
     # WHEN trying to add a tag to the non existing file

--- a/tests/cli/add/test_cli_add_version.py
+++ b/tests/cli/add/test_cli_add_version.py
@@ -37,7 +37,7 @@ def test_add_version_non_existing_bundle(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a non existing bundle
     bundle_name = "non_existing"
     bundle: Bundle = store.get_bundle_by_name(bundle_name=bundle_name)
@@ -61,9 +61,9 @@ def test_add_version_existing_bundle(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a existing bundle
-    bundle: Bundle = store.Bundle.query.first()
+    bundle: Bundle = store._get_query(table=Bundle).first()
     assert isinstance(bundle, Bundle)
 
     # GIVEN the name of a existing bundle
@@ -88,9 +88,9 @@ def test_add_version_existing_bundle_same_date(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a existing bundle
-    bundle: Bundle = store.Bundle.query.first()
+    bundle: Bundle = store._get_query(table=Bundle).first()
     assert isinstance(bundle, Bundle)
     bundle_name: str = bundle.name
 
@@ -119,7 +119,7 @@ def test_add_version_no_files_json(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     version_data = json.loads(empty_version_data_json)
     # GIVEN a bundle with one version
     bundle = store.get_bundle_by_name(bundle_name=version_data["bundle_name"])
@@ -149,7 +149,7 @@ def test_add_version_with_files_json(
     """Test to add a new version with files to existing bundle using json as input"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     version_data = json.loads(version_data_json)
     # GIVEN a bundle with one version
     bundle = store.get_bundle_by_name(bundle_name=version_data["bundle_name"])

--- a/tests/cli/add/test_cli_add_version.py
+++ b/tests/cli/add/test_cli_add_version.py
@@ -6,6 +6,7 @@ from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli.add import version_cmd
+from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle
 
 

--- a/tests/cli/delete/test_cli_delete_bundle.py
+++ b/tests/cli/delete/test_cli_delete_bundle.py
@@ -4,9 +4,12 @@ from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli import delete
+from housekeeper.store.api.core import Store
 
 
-def test_delete_non_existing_bundle(base_context: Context, cli_runner: CliRunner, caplog):
+def test_delete_non_existing_bundle(
+    base_context: Context, cli_runner: CliRunner, caplog
+):
     """Test to delete a non existing bundle"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a store and a cli runner
@@ -29,7 +32,7 @@ def test_delete_existing_bundle_with_version(
     """Test to delete an existing bundle with versions"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a bundle with versions
     bundle_obj = store.get_bundle_by_name(bundle_name=case_id)
     assert len(bundle_obj.versions) > 0
@@ -47,14 +50,18 @@ def test_delete_existing_bundle_no_versions_no_confirmation(
     """Test to delete an existing bundle without confirmation"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a bundle without versions
-    cli_runner.invoke(delete.version_cmd, ["-b", case_id], obj=populated_context, input="Yes")
+    cli_runner.invoke(
+        delete.version_cmd, ["-b", case_id], obj=populated_context, input="Yes"
+    )
     bundle_obj = store.get_bundle_by_name(bundle_name=case_id)
     assert len(bundle_obj.versions) == 0
 
     # WHEN trying to delete a bundle
-    result = cli_runner.invoke(delete.bundle_cmd, [case_id], obj=populated_context, input="no")
+    result = cli_runner.invoke(
+        delete.bundle_cmd, [case_id], obj=populated_context, input="no"
+    )
     # THEN assert it exits non zero
     assert result.exit_code == 1
 
@@ -65,14 +72,18 @@ def test_delete_existing_bundle_no_versions_with_confirmation(
     """Test to delete an existing bundle without confirmation"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a bundle without versions
-    cli_runner.invoke(delete.version_cmd, ["-b", case_id], obj=populated_context, input="Yes")
+    cli_runner.invoke(
+        delete.version_cmd, ["-b", case_id], obj=populated_context, input="Yes"
+    )
     bundle_obj = store.get_bundle_by_name(bundle_name=case_id)
     assert len(bundle_obj.versions) == 0
 
     # WHEN trying to delete a bundle
-    result = cli_runner.invoke(delete.bundle_cmd, [case_id], obj=populated_context, input="Yes")
+    result = cli_runner.invoke(
+        delete.bundle_cmd, [case_id], obj=populated_context, input="Yes"
+    )
     # THEN assert it exits non zero
     assert result.exit_code == 0
     # THEN it should communicate that it was deleted

--- a/tests/cli/delete/test_cli_delete_file.py
+++ b/tests/cli/delete/test_cli_delete_file.py
@@ -5,6 +5,8 @@ from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli import delete
+from housekeeper.store.api.core import Store
+from housekeeper.store.models import File
 
 
 def test_delete_non_existing_file(base_context: Context, cli_runner: CliRunner, caplog):

--- a/tests/cli/delete/test_cli_delete_file.py
+++ b/tests/cli/delete/test_cli_delete_file.py
@@ -14,7 +14,7 @@ def test_delete_non_existing_file(base_context: Context, cli_runner: CliRunner, 
     file_id = 1
     # GIVEN that the file does not exist
     store = base_context["store"]
-    file_obj = store.File.get(file_id)
+    file_obj: File = store.get_file_by_id(file_id=file_id)
     assert not file_obj
 
     # WHEN trying to delete the non existing file
@@ -34,7 +34,7 @@ def test_delete_existing_file_with_confirmation(
     store: Store = populated_context["store"]
     file_id = 1
     # GIVEN that the file exists
-    file_obj = store.File.get(file_id)
+    file_obj: File = store.get_file_by_id(file_id=file_id)
     assert file_obj
 
     # WHEN trying to delete the file
@@ -53,7 +53,7 @@ def test_delete_existing_file_no_confirmation(
     store: Store = populated_context["store"]
     file_id = 1
     # GIVEN that the file exists
-    file_obj = store.File.get(file_id)
+    file_obj: File = store.get_file_by_id(file_id=file_id)
     assert file_obj
 
     # WHEN trying to delete the file

--- a/tests/cli/delete/test_cli_delete_file.py
+++ b/tests/cli/delete/test_cli_delete_file.py
@@ -31,7 +31,7 @@ def test_delete_existing_file_with_confirmation(
 ):
     """Test to delete an existing file using confirmation"""
     # GIVEN a context with a populated store, a file id and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     file_id = 1
     # GIVEN that the file exists
     file_obj = store.File.get(file_id)
@@ -50,14 +50,16 @@ def test_delete_existing_file_no_confirmation(
     """Test to delete a existing file without confirmation"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store, a file id and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     file_id = 1
     # GIVEN that the file exists
     file_obj = store.File.get(file_id)
     assert file_obj
 
     # WHEN trying to delete the file
-    result = cli_runner.invoke(delete.file_cmd, [str(file_id), "--yes"], obj=populated_context)
+    result = cli_runner.invoke(
+        delete.file_cmd, [str(file_id), "--yes"], obj=populated_context
+    )
 
     # THEN file delete should be in output
     assert "file deleted" in caplog.text

--- a/tests/cli/delete/test_cli_delete_files.py
+++ b/tests/cli/delete/test_cli_delete_files.py
@@ -5,6 +5,7 @@ from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli import delete
+from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle
 
 

--- a/tests/cli/delete/test_cli_delete_files.py
+++ b/tests/cli/delete/test_cli_delete_files.py
@@ -52,7 +52,7 @@ def test_delete_existing_bundle_with_confirmation(
     caplog.set_level(logging.DEBUG)
 
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a existing bundle
     bundle: Bundle = store._get_query(table=Bundle).first()
@@ -75,7 +75,7 @@ def test_delete_existing_bundle_no_confirmation(
     caplog.set_level(logging.DEBUG)
 
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a existing bundle
     bundle: Bundle = store._get_query(table=Bundle).first()

--- a/tests/cli/get/test_get_bundle.py
+++ b/tests/cli/get/test_get_bundle.py
@@ -1,5 +1,6 @@
 """Tests for adding via CLI"""
 from housekeeper.cli.get import bundle_cmd
+from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle
 
 
@@ -7,7 +8,7 @@ def test_get_existing_bundle_name(populated_context, cli_runner, helpers):
     """Test to fetch an existing bundle based on name"""
 
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a existing bundle
     bundle: Bundle = store._get_query(table=Bundle).first()
@@ -28,7 +29,7 @@ def test_get_existing_bundle_verbose(populated_context, cli_runner, helpers):
     """Test to fetch an existing bundle based on name with verbose information"""
 
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a existing bundle
     bundle: Bundle = store._get_query(table=Bundle).first()
@@ -66,7 +67,7 @@ def test_get_non_existing_bundle_populated_store(
 ):
     """Test to fetch a non existing bundle based on name when bundles exists"""
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a non empty store
     assert helpers.count_iterable(store.bundles()) > 0
@@ -86,10 +87,10 @@ def test_get_non_existing_bundle_populated_store(
 def test_get_existing_bundle_id(populated_context, cli_runner, helpers):
     """Test to fetch an existing bundle based on bundle id"""
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a existing bundle
-    bundle = store.Bundle.query.first()
+    bundle = store._get_query(table=Bundle).first()
     bundle_id = bundle.id
 
     # WHEN trying to fetch a bundle based on bundle id
@@ -108,10 +109,10 @@ def test_get_bundle_json(populated_context, cli_runner, helpers):
     """Test to fetch a bundle in json format"""
 
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
 
     # GIVEN a existing bundle
-    bundle = store.Bundle.query.first()
+    bundle = store._get_query(table=Bundle).first()
     bundle_id = bundle.id
 
     # WHEN fetching the bundle in json format
@@ -134,7 +135,7 @@ def test_get_bundles_multiple_bundles(
     """Test to get all bundles when there are more than one bundle"""
 
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     helpers.add_bundle(store, other_bundle)
 
     # GIVEN a store with more than one bundles

--- a/tests/cli/get/test_get_files.py
+++ b/tests/cli/get/test_get_files.py
@@ -25,7 +25,7 @@ def test_get_files_no_files(base_context, cli_runner, helpers):
 def test_get_files_json(populated_context, cli_runner, helpers):
     """Test to get all files from a populated store"""
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a store with some files
     nr_files = helpers.count_iterable(store.get_files())
     assert nr_files > 0
@@ -43,7 +43,7 @@ def test_get_files(populated_context, cli_runner):
     """Test to get all files from a populated store in human friendly format"""
     # GIVEN a context with a populated store and a cli runner
     # GIVEN a store with some files
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a file name
     file_obj = store.get_files().first()
     file_name = Path(file_obj.path).name
@@ -60,7 +60,7 @@ def test_get_files(populated_context, cli_runner):
 def test_get_files_tag(populated_context, cli_runner, helpers, vcf_tag_name):
     """Test to get files with a specific tag from a populated store"""
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a store with some files that are tagged
     nr_files = helpers.count_iterable(store.get_files(tag_names=[vcf_tag_name]))
     assert nr_files > 0
@@ -81,7 +81,7 @@ def test_get_files_multiple_tags(
 ):
     """Test to get files with multiple tags tag from a populated store"""
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a store with some files that are tagged
     nr_files = helpers.count_iterable(
         store.get_files(tag_names=[vcf_tag_name, family_tag_name])
@@ -104,7 +104,7 @@ def test_get_files_multiple_tags(
 def test_get_files_rare_tag(populated_context, cli_runner, helpers, family_tag_name):
     """Test to get files with a tag that is not on all files from a populated store"""
     # GIVEN a context with a populated store and a cli runner
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a store with some files that are tagged
     total_nr_files = helpers.count_iterable(store.get_files())
     nr_tag_files = helpers.count_iterable(store.get_files(tag_names=[family_tag_name]))

--- a/tests/cli/get/test_get_files.py
+++ b/tests/cli/get/test_get_files.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 from housekeeper.cli.get import files_cmd
 from housekeeper.cli.tables import squash_names, _get_suffix
+from housekeeper.store.api.core import Store
 
 
 def test_get_files_no_files(base_context, cli_runner, helpers):

--- a/tests/cli/get/test_get_version.py
+++ b/tests/cli/get/test_get_version.py
@@ -36,8 +36,8 @@ def test_get_version_bundle_name(
     This should return all versions
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle_obj: Bundle = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle_obj: Bundle = store._get_query(table=Bundle).first()
     version_obj: Version = bundle_obj.versions[0]
     bundle_name: str = bundle_obj.name
 
@@ -56,7 +56,7 @@ def test_get_version_non_existing_bundle_name(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context that is populated
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a non existing bundle name
     bundle_name = "hello"
     assert not store.get_bundle_by_name(bundle_name=bundle_name)
@@ -74,8 +74,8 @@ def test_get_version_json(populated_context: Context, cli_runner: CliRunner, hel
     This should return all versions
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle_obj = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle_obj = store._get_query(table=Bundle).first()
     bundle_name = bundle_obj.name
 
     # WHEN running the include files command
@@ -95,8 +95,8 @@ def test_get_version_version_id(
     This should return all versions
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle_obj: Bundle = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle_obj: Bundle = store._get_query(table=Bundle).first()
     version_obj: Version = bundle_obj.versions[0]
     version_id: int = version_obj.id
 

--- a/tests/cli/get/test_get_version.py
+++ b/tests/cli/get/test_get_version.py
@@ -6,6 +6,7 @@ from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli.get import version_cmd
+from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle, Version
 
 

--- a/tests/cli/test_cli_include.py
+++ b/tests/cli/test_cli_include.py
@@ -18,8 +18,8 @@ def test_include_files_creates_bundle_dir(
     The bundle should not exist before and after command is run it should have been created
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle: Bundle = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle: Bundle = store._get_query(table=Bundle).first()
     bundle_name: str = bundle.name
     # GIVEN that the latest version of the bundle is not included
     assert bundle.versions[0].included_at is None
@@ -42,8 +42,8 @@ def test_include_files_creates_version_specific_bundle_dir(
     The version bundle should not exist before and after command is run it should have been created
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle: Bundle = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle: Bundle = store._get_query(table=Bundle).first()
     version_obj = bundle.versions[0]
     bundle_name: str = bundle.name
     # GIVEN that the latest version of the bundle is not included
@@ -69,8 +69,8 @@ def test_include_files_adds_version_specific_files(
     The files should have been hard linked after command has been run
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle: Bundle = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle: Bundle = store._get_query(table=Bundle).first()
     version_obj = bundle.versions[0]
     bundle_name: str = bundle.name
     # GIVEN that the latest version of the bundle is not included
@@ -101,8 +101,8 @@ def test_include_files_specific_version(
     The folder should have been created
     """
     # GIVEN a context that is populated
-    store = populated_context["store"]
-    bundle: Bundle = store.Bundle.query.first()
+    store: Store = populated_context["store"]
+    bundle: Bundle = store._get_query(table=Bundle).first()
     version_obj = bundle.versions[0]
     version_id = version_obj.id
     # GIVEN that the latest version of the bundle is not included
@@ -156,7 +156,7 @@ def test_include_non_existing_version(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context that is populated
-    store = populated_context["store"]
+    store: Store = populated_context["store"]
     # GIVEN a version that does not exists
     version_id = 10
     assert not store.Version.get(version_id)
@@ -231,8 +231,8 @@ def test_include_version_already_included(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN a context that is populated and a version that is already included
-    store = populated_context["store"]
-    version_obj = store.Version.query.first()
+    store: Store = populated_context["store"]
+    version_obj = store._get_query(table=Version).first()
     version_id = version_obj.id
     result = cli_runner.invoke(
         include, ["--version-id", version_id], obj=populated_context

--- a/tests/cli/test_cli_include.py
+++ b/tests/cli/test_cli_include.py
@@ -6,6 +6,7 @@ from click.testing import CliRunner
 
 from housekeeper.cli.include import include
 from housekeeper.cli.add import bundle_cmd
+from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle
 
 
@@ -202,11 +203,12 @@ def test_include_bundle_without_version(
     """
     caplog.set_level(logging.DEBUG)
     # GIVEN context with a bundle without versions
-    store = base_context["store"]
+    store: Store = base_context["store"]
     bundle_name = "hello"
 
     new_bundle = store.new_bundle(name=bundle_name, created_at=timestamp)
-    store.add_commit(new_bundle)
+    store.session.add(new_bundle)
+    store.session.commit()
 
     bundle = store.get_bundle_by_name(bundle_name=bundle_name)
     assert len(bundle.versions) == 0

--- a/tests/cli/test_cli_include.py
+++ b/tests/cli/test_cli_include.py
@@ -7,7 +7,7 @@ from click.testing import CliRunner
 from housekeeper.cli.include import include
 from housekeeper.cli.add import bundle_cmd
 from housekeeper.store.api.core import Store
-from housekeeper.store.models import Bundle
+from housekeeper.store.models import Bundle, Version
 
 
 def test_include_files_creates_bundle_dir(
@@ -159,7 +159,7 @@ def test_include_non_existing_version(
     store: Store = populated_context["store"]
     # GIVEN a version that does not exists
     version_id = 10
-    assert not store.Version.get(version_id)
+    assert not store.get_version_by_id(version_id=version_id)
 
     # WHEN running the include files specifying the non existing version
     result = cli_runner.invoke(

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -38,10 +38,13 @@ class Helpers:
     def add_bundle(store: Store, bundle: dict) -> None:
         """Add and commit bundle to housekeeper store"""
         bundle_obj, _ = store.add_bundle(bundle)
-        store.add_commit(bundle_obj)
+        store.session.add(bundle_obj)
+        store.session.commit()
 
     @staticmethod
-    def create_bundle_data(case_id: str, files: List[dict], created_at: dt.datetime = None) -> dict:
+    def create_bundle_data(
+        case_id: str, files: List[dict], created_at: dt.datetime = None
+    ) -> dict:
         """
         Create a new bundle_data dictionary with the given parameters.
 
@@ -53,7 +56,10 @@ class Helpers:
         if created_at is None:
             created_at = dt.datetime.now()
 
-        files = [{"path": str(file_data["file"]), "archive": True, "tags": file_data["tags"]} for file_data in files]
+        files = [
+            {"path": str(file_data["file"]), "archive": True, "tags": file_data["tags"]}
+            for file_data in files
+        ]
 
         data = {
             "name": case_id,

--- a/tests/store/test_add_core.py
+++ b/tests/store/test_add_core.py
@@ -1,50 +1,50 @@
 """Tests for store core functions"""
 
-from housekeeper.store import models
+from housekeeper.store.models import Bundle, File, Tag, Version
 from housekeeper.store.api.core import Store
 
 # tag tests
 
 
-def test_create_tag_obj(store, vcf_tag_name):
+def test_create_tag_obj(store: Store, vcf_tag_name):
     """Test to create a tag object"""
     # GIVEN a store and a tag name
     # WHEN creating a tag
     new_tag = store.new_tag(vcf_tag_name)
     # THEN assert a tag object was created
-    assert isinstance(new_tag, models.Tag)
+    assert isinstance(new_tag, Tag)
     assert new_tag.name == vcf_tag_name
 
 
 def test_add_tag(store: Store, vcf_tag_obj):
     """Test to add a tag"""
     # GIVEN a store without tags
-    assert store.Tag.query.count() == 0
+    assert store._get_query(table=Tag).count() == 0
     # WHEN adding a tag
     store.session.add(vcf_tag_obj)
     store.session.commit()
     # THEN assert the new tag was added
-    assert store.Tag.query.count() == 1
-    assert store.Tag.query.first() == vcf_tag_obj
+    assert store._get_query(table=Tag).count() == 1
+    assert store._get_query(table=Tag).first() == vcf_tag_obj
 
 
 # version tests
 
 
-def test_create_version_obj(store, timestamp):
+def test_create_version_obj(store: Store, timestamp):
     """Test to create a version object"""
     # GIVEN a store and a time stamp
     # WHEN creating a version
     new_version = store.new_version(created_at=timestamp, expires_at=timestamp)
     # THEN assert a version object was created
-    assert isinstance(new_version, models.Version)
+    assert isinstance(new_version, Version)
     assert new_version.created_at == timestamp
 
 
 # bundle tests
 
 
-def test_create_bundle_obj(store, bundle_data):
+def test_create_bundle_obj(store: Store, bundle_data):
     """Test to create a bundle object"""
     # GIVEN some bundle information
     # WHEN adding the new bundle
@@ -62,41 +62,41 @@ def test_create_bundle_obj(store, bundle_data):
 def test_add_bundle(store: Store, bundle_obj):
     """Test to add a bundle to the store"""
     # GIVEN a store without files, tags, versions or bundles
-    assert store.Bundle.query.count() == 0
-    assert store.Tag.query.count() == 0
-    assert store.Version.query.count() == 0
-    assert store.File.query.count() == 0
+    assert store._get_query(table=Bundle).count() == 0
+    assert store._get_query(table=Tag).count() == 0
+    assert store._get_query(table=Version).count() == 0
+    assert store._get_query(table=File).count() == 0
     # WHEN adding the new bundle
     store.session.add(bundle_obj)
     store.session.commit()
     # THEN assert that a bundle was added
-    assert store.Bundle.query.count() == 1
+    assert store._get_query(table=Bundle).count() == 1
     # THEN assert that the bundle is correct
-    assert store.Bundle.query.first() == bundle_obj
+    assert store._get_query(table=Bundle).first() == bundle_obj
     # THEN assert some tags where added
-    assert store.Tag.query.count() > 0
+    assert store._get_query(table=Tag).count() > 0
     # THEN assert some files where added
-    assert store.File.query.count() > 0
+    assert store._get_query(table=File).count() > 0
     # THEN assert we have a version
-    assert store.Version.query.count() > 0
+    assert store._get_query(table=Version).count() > 0
 
 
-def test_add_bundle_twice(populated_store, bundle_data):
+def test_add_bundle_twice(populated_store: Store, bundle_data):
     """Test to add a bundle twice"""
     store = populated_store
     # GIVEN a store ppopulated with a bundle
-    assert store.Bundle.query.count() > 0
+    assert store._get_query(table=Bundle).count() > 0
     # WHEN adding the same bundle again
     new_bundle = store.add_bundle(bundle_data)
     # THEN it should return None
     assert new_bundle is None
 
 
-def test_add_two_versions_of_bundle(populated_store, second_bundle_data):
+def test_add_two_versions_of_bundle(populated_store: Store, second_bundle_data):
     """Test to add two versions of the same bundle"""
     store: Store = populated_store
     # GIVEN a populated store and some modified bundle data
-    assert store.Bundle.query.count() > 0
+    assert store._get_query(table=Bundle).count() > 0
 
     # WHEN adding the modified bundle to the database
     new_bundle_obj = store.add_bundle(second_bundle_data)[0]
@@ -104,8 +104,8 @@ def test_add_two_versions_of_bundle(populated_store, second_bundle_data):
     store.session.commit()
 
     # THEN there should still be one bundle
-    assert store.Bundle.query.count() == 1
+    assert store._get_query(table=Bundle).count() == 1
     # THEN there should be two versions
-    assert store.Version.query.count() == 2
+    assert store._get_query(table=Version).count() == 2
     # THEN tere should be all four files
-    assert store.File.query.count() == 4
+    assert store._get_query(table=File).count() == 4

--- a/tests/store/test_add_core.py
+++ b/tests/store/test_add_core.py
@@ -1,6 +1,7 @@
 """Tests for store core functions"""
 
 from housekeeper.store import models
+from housekeeper.store.api.core import Store
 
 # tag tests
 
@@ -15,12 +16,13 @@ def test_create_tag_obj(store, vcf_tag_name):
     assert new_tag.name == vcf_tag_name
 
 
-def test_add_tag(store, vcf_tag_obj):
+def test_add_tag(store: Store, vcf_tag_obj):
     """Test to add a tag"""
     # GIVEN a store without tags
     assert store.Tag.query.count() == 0
     # WHEN adding a tag
-    store.add_commit(vcf_tag_obj)
+    store.session.add(vcf_tag_obj)
+    store.session.commit()
     # THEN assert the new tag was added
     assert store.Tag.query.count() == 1
     assert store.Tag.query.first() == vcf_tag_obj
@@ -57,7 +59,7 @@ def test_create_bundle_obj(store, bundle_data):
     assert len(bundle_obj.versions[0].files) == len(bundle_data["files"])
 
 
-def test_add_bundle(store, bundle_obj):
+def test_add_bundle(store: Store, bundle_obj):
     """Test to add a bundle to the store"""
     # GIVEN a store without files, tags, versions or bundles
     assert store.Bundle.query.count() == 0
@@ -65,7 +67,8 @@ def test_add_bundle(store, bundle_obj):
     assert store.Version.query.count() == 0
     assert store.File.query.count() == 0
     # WHEN adding the new bundle
-    store.add_commit(bundle_obj)
+    store.session.add(bundle_obj)
+    store.session.commit()
     # THEN assert that a bundle was added
     assert store.Bundle.query.count() == 1
     # THEN assert that the bundle is correct
@@ -91,13 +94,14 @@ def test_add_bundle_twice(populated_store, bundle_data):
 
 def test_add_two_versions_of_bundle(populated_store, second_bundle_data):
     """Test to add two versions of the same bundle"""
-    store = populated_store
+    store: Store = populated_store
     # GIVEN a populated store and some modified bundle data
     assert store.Bundle.query.count() > 0
 
     # WHEN adding the modified bundle to the database
     new_bundle_obj = store.add_bundle(second_bundle_data)[0]
-    store.add_commit(new_bundle_obj)
+    store.session.add(new_bundle_obj)
+    store.session.commit()
 
     # THEN there should still be one bundle
     assert store.Bundle.query.count() == 1

--- a/tests/store/test_store_api.py
+++ b/tests/store/test_store_api.py
@@ -1,6 +1,7 @@
 """Tests for the store api"""
 import datetime
 from typing import List
+from housekeeper.store.api.core import Store
 
 from housekeeper.store.models import File
 
@@ -9,10 +10,11 @@ def test_get_files_before(populated_store, bundle_data_old, time_stamp_now):
     """
     Test return all files when two bundles are added.
     """
-    store = populated_store
+    store: Store = populated_store
     # GIVEN a store with two bundles and two files in each bundle
     bundle_old_obj, _ = store.add_bundle(data=bundle_data_old)
-    store.add_commit(bundle_old_obj)
+    store.session.add(bundle_old_obj)
+    store.session.commit()
 
     # WHEN fetching all files in the database
     files = store.get_files_before(before_date=time_stamp_now)
@@ -25,10 +27,11 @@ def test_get_past_files(populated_store, bundle_data_old, timestamp, old_timesta
     """
     test fetch files where not all files are older than before date
     """
-    store = populated_store
+    store: Store = populated_store
     # GIVEN a store with two bundles and two files in each bundle
     bundle_old_obj, _ = store.add_bundle(data=bundle_data_old)
-    store.add_commit(bundle_old_obj)
+    store.session.add(bundle_old_obj)
+    store.session.commit()
 
     # WHEN fetching all files before the oldest date
     date = old_timestamp + datetime.timedelta(days=10)
@@ -48,10 +51,11 @@ def test_get_no_get_files_before_oldest(
     """
     Test get files where no files are older than before date.
     """
-    store = populated_store
+    store: Store = populated_store
     # GIVEN a store with two bundles and two files in each bundle
     bundle_old_obj, _ = store.add_bundle(data=bundle_data_old)
-    store.add_commit(bundle_old_obj)
+    store.session.add(bundle_old_obj)
+    store.session.commit()
 
     # WHEN fetching all files before the oldest date
     date = old_timestamp - datetime.timedelta(days=10)


### PR DESCRIPTION
## Description
Replacing alchy with sqlalchemy in Housekeeper.

### Changed
-  Replaced `commit` with `session.commit`
- Replaced `add_commit` with `session.add` followed by `session.commit`
- Replaced `delete` with `session.delete`
- Replaced all `alchy` imports with `sqlalchemy`
- The Store is now instantiated with a session, which is sent up to all the handlers.
- Remove alchy in `requirements.txt`



## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b YOURBRANCH```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MINOR** - when you add functionality in a backwards compatible manner

