### PR TITLE
Remove models from base handler

### DIFF
--- a/housekeeper/store/api/add.py
+++ b/housekeeper/store/api/add.py
@@ -26,7 +26,7 @@ class AddHandler(BaseHandler):
 
     def new_bundle(self, name: str, created_at: dt.datetime = None) -> models.Bundle:
         """Create a new file bundle."""
-        new_bundle = self.Bundle(name=name, created_at=created_at)
+        new_bundle = models.Bundle(name=name, created_at=created_at)
         LOG.info("Created new bundle: %s", new_bundle.name)
         return new_bundle
 
@@ -85,7 +85,7 @@ class AddHandler(BaseHandler):
     ) -> models.Version:
         """Create a new bundle version."""
         LOG.info("Created new version")
-        new_version = self.Version(created_at=created_at, expires_at=expires_at)
+        new_version = models.Version(created_at=created_at, expires_at=expires_at)
         return new_version
 
     def add_version(
@@ -153,12 +153,12 @@ class AddHandler(BaseHandler):
         tags: List[models.Tag] = None,
     ) -> models.File:
         """Create a new file object based on the information given."""
-        new_file = self.File(
+        new_file = models.File(
             path=path, checksum=checksum, to_archive=to_archive, tags=tags
         )
         return new_file
 
     def new_tag(self, name: str, category: str = None) -> models.Tag:
         """Create a new tag object based on the information given."""
-        new_tag = self.Tag(name=name, category=category)
+        new_tag = models.Tag(name=name, category=category)
         return new_tag

--- a/housekeeper/store/api/base.py
+++ b/housekeeper/store/api/base.py
@@ -8,11 +8,6 @@ from sqlalchemy.orm import Query, Session
 class BaseHandler:
     """This is a base class holding different models"""
 
-    Bundle: Type[Model] = Bundle
-    Version: Type[Model] = Version
-    File: Type[Model] = File
-    Tag: Type[Model] = Tag
-
     def __init__(self, session: Session):
         self.session = session
 

--- a/housekeeper/store/api/core.py
+++ b/housekeeper/store/api/core.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 
-from housekeeper.store.models import Model
+from housekeeper.store.models import File, Model, Version
 from housekeeper.store.api.add import AddHandler
 from housekeeper.store.api.find import FindHandler
 
@@ -38,8 +38,8 @@ class Store(CoreHandler):
         self.session = scoped_session(session_factory)
 
         LOG.debug("Initializing Store")
-        self.File.app_root = Path(root)
-        self.Version.app_root = Path(root)
+        File.app_root = Path(root)
+        Version.app_root = Path(root)
 
         super().__init__(self.session)
 

--- a/housekeeper/store/api/find.py
+++ b/housekeeper/store/api/find.py
@@ -120,7 +120,7 @@ class FindHandler(BaseHandler):
         if bundle_name:
             LOG.info(f"Fetching files from bundle {bundle_name}")
             query = apply_bundle_filter(
-                bundles=query.join(self.File.version, self.Version.bundle),
+                bundles=query.join(File.version, Version.bundle),
                 filter_functions=[BundleFilters.FILTER_BY_NAME],
                 bundle_name=bundle_name,
             )
@@ -138,7 +138,7 @@ class FindHandler(BaseHandler):
         if version_id:
             LOG.info(f"Fetching files from version {version_id}")
             query = apply_version_filter(
-                versions=query.join(self.File.version),
+                versions=query.join(File.version),
                 filter_functions=[VersionFilter.FILTER_BY_ID],
                 version_id=version_id,
             )


### PR DESCRIPTION
## Description
Remove models from base handler. I think cg uses these, so some patches need to be applied in cg and housekeeper before merging this.


### Changed
- Remove unnecessary models from base handler

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
