### PR TITLE
115 - include file in housekeeper-bundles by default

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Generator, List
 
 import click
+from housekeeper.constants import ROOT
 from housekeeper.date import get_date
 from housekeeper.files import load_json, validate_input
 from housekeeper.store import Store
@@ -117,9 +118,8 @@ def file_cmd(
         raise click.Abort
 
     tags = data.get("tags", tags)
-
     new_file = store.add_file(
-        file_path=file_path, bundle=bundle, tags=tags, exclude=exclude, root=context.obj["root"]
+        file_path=file_path, bundle=bundle, tags=tags, exclude=exclude, root=context.obj[ROOT]
     )
     store.session.add(new_file)
     store.session.commit()

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -8,7 +8,6 @@ from typing import Dict, Generator, List
 import click
 from housekeeper.date import get_date
 from housekeeper.files import load_json, validate_input
-from housekeeper.include import link_file
 from housekeeper.store import Store
 from housekeeper.store.models import Bundle, File, Tag, Version
 
@@ -88,7 +87,12 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str):
 @click.argument("path", required=False)
 @click.pass_context
 def file_cmd(
-    context: click.Context, tags: List[str], bundle_name: str, json: str, path: str, exclude: bool
+    context: click.Context,
+    tags: List[str],
+    bundle_name: str,
+    json: str,
+    exclude: bool,
+    path: str,
 ):
     """Add a file to the latest version of a bundle."""
     LOG.info("Running add file")
@@ -112,26 +116,14 @@ def file_cmd(
         LOG.warning("unknown bundle: %s", bundle_name)
         raise click.Abort
 
-    if not exclude:
-        file_path = _link_and_convert_to_relative_path_(
-            absolute_path=file_path, root_path=Path(context.obj["root"]), version=bundle.versions[0]
-        )
-
     tags = data.get("tags", tags)
 
-    new_file = store.add_file(file_path=file_path, bundle=bundle, tags=tags)
+    new_file = store.add_file(
+        file_path=file_path, bundle=bundle, tags=tags, exclude=exclude, root=context.obj["root"]
+    )
     store.session.add(new_file)
     store.session.commit()
     LOG.info("new file added: %s (%s)", new_file.path, new_file.id)
-
-
-def _link_and_convert_to_relative_path_(
-    absolute_path: Path, root_path: Path, version: Version
-) -> Path:
-    """Link the given absolute path to its path when included in the given version and return the relative path."""
-    housekeeper_path: Path = root_path / version.relative_root_dir / absolute_path.name
-    link_file(file_path=absolute_path, new_path=housekeeper_path, hardlink=True)
-    return version.relative_root_dir / absolute_path.name
 
 
 @add.command("version")

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -9,8 +9,9 @@ import click
 from housekeeper.constants import ROOT
 from housekeeper.date import get_date
 from housekeeper.files import load_json, validate_input
+from housekeeper.include import link_to_relative_path, relative_path
 from housekeeper.store import Store
-from housekeeper.store.models import Bundle, File, Tag, Version
+from housekeeper.store.models import Bundle, Tag, Version
 
 LOG: Logger = logging.getLogger(__name__)
 
@@ -78,12 +79,12 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str):
 @click.option("-b", "--bundle-name", help="name of bundle that file should be added to")
 @click.option("-j", "--json", help="json formatted input")
 @click.option(
-    "-e",
-    "--exclude",
+    "-kip",
+    "--keep-input-path",
     is_flag=True,
     default=False,
     show_default=True,
-    help="Flag to exclude the file from housekeeper",
+    help="flag to use the input path in housekeeper",
 )
 @click.argument("path", required=False)
 @click.pass_context
@@ -92,7 +93,7 @@ def file_cmd(
     tags: List[str],
     bundle_name: str,
     json: str,
-    exclude: bool,
+    keep_input_path: bool,
     path: str,
 ):
     """Add a file to the latest version of a bundle."""
@@ -118,9 +119,11 @@ def file_cmd(
         raise click.Abort
 
     tags = data.get("tags", tags)
-    new_file = store.add_file(
-        file_path=file_path, bundle=bundle, tags=tags, exclude=exclude, root=context.obj[ROOT]
-    )
+    if not keep_input_path:
+        version: Version = bundle.versions[0]
+        link_to_relative_path(version=version, file_path=file_path, root_path=context.obj[ROOT])
+        file_path = relative_path(version=version, file=file_path)
+    new_file = store.add_file(file_path=file_path, bundle=bundle, tags=tags)
     store.session.add(new_file)
     store.session.commit()
     LOG.info("new file added: %s (%s)", new_file.path, new_file.id)
@@ -172,7 +175,7 @@ def tag_cmd(context: click.Context, tags: List[str], file_id: int):
     LOG.info("Running add tag")
     store: Store = context.obj["store"]
     file = None
-    if len(tags) == 0:
+    if not tags:
         LOG.warning("No tags provided")
         raise click.Abort
 

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -84,7 +84,7 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str):
     is_flag=True,
     default=False,
     show_default=True,
-    help="flag to use the input path in housekeeper",
+    help="Flag to use the input path in Housekeeper",
 )
 @click.argument("path", required=False)
 @click.pass_context
@@ -106,7 +106,7 @@ def file_cmd(
         data: Dict = load_json(json)
         validate_input(data, input_type="file")
 
-    file_path = Path(data.get("path", path))
+    file_path: Path = Path(data.get("path", path))
     if not file_path.exists():
         LOG.warning("File: %s does not exist", file_path)
         raise click.Abort
@@ -122,7 +122,7 @@ def file_cmd(
     if not keep_input_path:
         version: Version = bundle.versions[0]
         link_to_relative_path(version=version, file_path=file_path, root_path=context.obj[ROOT])
-        file_path = relative_path(version=version, file=file_path)
+        file_path: Path = relative_path(version=version, file=file_path)
     new_file = store.add_file(file_path=file_path, bundle=bundle, tags=tags)
     store.session.add(new_file)
     store.session.commit()

--- a/housekeeper/cli/core.py
+++ b/housekeeper/cli/core.py
@@ -4,11 +4,11 @@ from typing import Optional
 
 import click
 import coloredlogs
-import yaml
-
 import housekeeper
+import yaml
 from housekeeper.store import Store
 
+from ..constants import ROOT
 from . import add, delete, get, include, init
 
 LOG = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def base(
         config_values = yaml.full_load(config)
     context.obj = config_values
     db_path = database or context.obj.get("database")
-    root_path = context.obj["root"] = root or context.obj.get("root")
+    root_path = context.obj[ROOT] = root or context.obj.get(ROOT)
     if not db_path:
         LOG.error("Please point to a database")
         raise click.Abort

--- a/housekeeper/cli/core.py
+++ b/housekeeper/cli/core.py
@@ -6,9 +6,9 @@ import click
 import coloredlogs
 import housekeeper
 import yaml
+from housekeeper.constants import ROOT
 from housekeeper.store import Store
 
-from ..constants import ROOT
 from . import add, delete, get, include, init
 
 LOG = logging.getLogger(__name__)

--- a/housekeeper/cli/include.py
+++ b/housekeeper/cli/include.py
@@ -3,7 +3,7 @@ import datetime as dt
 import logging
 
 import click
-
+from housekeeper.constants import ROOT
 from housekeeper.exc import VersionIncludedError
 from housekeeper.include import include_version
 from housekeeper.store.api.core import Store
@@ -47,7 +47,7 @@ def include(context: click.Context, bundle_name: str, version_id: int):
         version_obj = bundle.versions[0]
 
     try:
-        include_version(context.obj["root"], version_obj)
+        include_version(context.obj[ROOT], version_obj)
     except VersionIncludedError as error:
         LOG.warning(error.message)
         raise click.Abort

--- a/housekeeper/constants.py
+++ b/housekeeper/constants.py
@@ -7,3 +7,4 @@ PIPELINES = ("mip",)
 TIME_TO_CLEANUP = timedelta(days=(30 * 3))
 ARCHIVE_TYPES = ("data", "result", "meta", "archive")
 EXTRA_STATUSES = ["coverage", "frequency", "genotype", "visualizer", "rawdata", "qc"]
+ROOT = "root"

--- a/housekeeper/constants.py
+++ b/housekeeper/constants.py
@@ -7,4 +7,4 @@ PIPELINES = ("mip",)
 TIME_TO_CLEANUP = timedelta(days=(30 * 3))
 ARCHIVE_TYPES = ("data", "result", "meta", "archive")
 EXTRA_STATUSES = ["coverage", "frequency", "genotype", "visualizer", "rawdata", "qc"]
-ROOT = "root"
+ROOT: str = "root"

--- a/housekeeper/include.py
+++ b/housekeeper/include.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 from housekeeper.exc import VersionIncludedError
-from housekeeper.store import models
+from housekeeper.store.models import Version
 
 BLOCKSIZE = 65536
 EMPTY_STR = ""
@@ -23,7 +23,7 @@ def link_file(file_path: Path, new_path: Path, hardlink: bool = True) -> None:
     LOG.info("linked file: %s -> %s", file_path, new_path)
 
 
-def include_version(global_root: str, version_obj: models.Version, hardlink: bool = True):
+def include_version(global_root: str, version_obj: Version, hardlink: bool = True):
     """Include files in existing bundle version.
 
     Including a file means to link them into a folder in the root directory
@@ -57,11 +57,11 @@ def checksum(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def link_to_relative_path(file_path: Path, root_path: Path, version: models.Version) -> None:
+def link_to_relative_path(file_path: Path, root_path: Path, version: Version) -> None:
     """Link the given absolute path to its path when included in the given version and return the relative path."""
     housekeeper_path: Path = Path(root_path, version.relative_root_dir, file_path.name)
     link_file(file_path=file_path, new_path=housekeeper_path, hardlink=True)
 
 
-def relative_path(version: models.Version, file: Path) -> Path:
+def relative_path(version: Version, file: Path) -> Path:
     return Path(version.relative_root_dir, file.name)

--- a/housekeeper/include.py
+++ b/housekeeper/include.py
@@ -55,3 +55,13 @@ def checksum(path: Path) -> str:
             hasher.update(buf)
             buf = stream.read(BLOCKSIZE)
     return hasher.hexdigest()
+
+
+def link_to_relative_path(file_path: Path, root_path: Path, version: models.Version) -> None:
+    """Link the given absolute path to its path when included in the given version and return the relative path."""
+    housekeeper_path: Path = Path(root_path, version.relative_root_dir, file_path.name)
+    link_file(file_path=file_path, new_path=housekeeper_path, hardlink=True)
+
+
+def relative_path(version: models.Version, file: Path) -> Path:
+    return Path(version.relative_root_dir, file.name)

--- a/housekeeper/store/api/handlers/create.py
+++ b/housekeeper/store/api/handlers/create.py
@@ -14,6 +14,13 @@ from sqlalchemy.orm import Session
 LOG = logging.getLogger(__name__)
 
 
+def _link_and_convert_to_relative_path(file_path: Path, root_path: Path, version: Version) -> Path:
+    """Link the given absolute path to its path when included in the given version and return the relative path."""
+    housekeeper_path: Path = root_path / version.relative_root_dir / file_path.name
+    link_file(file_path=file_path, new_path=housekeeper_path, hardlink=True)
+    return version.relative_root_dir / file_path.name
+
+
 class CreateHandler(BaseHandler):
     """Handles adding things to the store"""
 
@@ -120,7 +127,7 @@ class CreateHandler(BaseHandler):
         file_path_to_use: str = str(file_path.absolute())
         if not exclude:
             file_path_to_use = str(
-                self._link_and_convert_to_relative_path(
+                _link_and_convert_to_relative_path(
                     file_path=file_path, root_path=root, version=version_obj
                 )
             )
@@ -131,14 +138,6 @@ class CreateHandler(BaseHandler):
         )
         new_file.version = version_obj
         return new_file
-
-    def _link_and_convert_to_relative_path(
-        self, file_path: Path, root_path: Path, version: Version
-    ) -> Path:
-        """Link the given absolute path to its path when included in the given version and return the relative path."""
-        housekeeper_path: Path = root_path / version.relative_root_dir / file_path.name
-        link_file(file_path=file_path, new_path=housekeeper_path, hardlink=True)
-        return version.relative_root_dir / file_path.name
 
     def _build_tags(self, tag_names: List[str]) -> Dict[str, Tag]:
         """Build a list of tag objects.

--- a/housekeeper/store/api/handlers/create.py
+++ b/housekeeper/store/api/handlers/create.py
@@ -5,7 +5,6 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Tuple
 
-from housekeeper.include import link_file, link_to_relative_path, relative_path
 from housekeeper.store.api.handlers.base import BaseHandler
 from housekeeper.store.api.handlers.read import ReadHandler
 from housekeeper.store.models import Archive, Bundle, File, Tag, Version

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -18,9 +18,9 @@ def test_add_file_non_existing_bundle(
 ):
     """Test to add a file to a non existing bundle"""
     caplog.set_level(logging.DEBUG)
+
     # GIVEN a context with a empty store and a cli runner
     unknown_bundle_name = case_id
-
     # WHEN trying to add a bundle
     result = cli_runner.invoke(
         file_cmd, [str(second_sample_vcf), "-b", unknown_bundle_name], obj=base_context
@@ -114,10 +114,10 @@ def test_add_file_existing_bundle_with_include(
     # THEN check that the proper information is displayed
     assert "new file added" in caplog.text
     # THEN check that the file has been included in the version and that the relative path is given
-    assert (housekeeper_version_dir / second_sample_vcf.name).exists()
-    assert (housekeeper_version_dir / second_sample_vcf.name).is_file()
-    assert Path(version_obj.files[2].path) == Path(version_obj.relative_root_dir) / Path(
-        second_sample_vcf.name
+    assert Path(housekeeper_version_dir, second_sample_vcf.name).exists()
+    assert Path(housekeeper_version_dir, second_sample_vcf.name).is_file()
+    assert Path(version_obj.files[2].path) == Path(
+        version_obj.relative_root_dir, second_sample_vcf.name
     )
 
 

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -137,7 +137,7 @@ def test_add_file_existing_bundle_without_include(
     # WHEN trying to add the file to a bundle
     result = cli_runner.invoke(
         file_cmd,
-        [str(second_sample_vcf), "-b", bundle_name, "-e"],
+        [str(second_sample_vcf), "-b", bundle_name, "-kip"],
         obj=populated_context,
     )
 

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from click import Context
 from click.testing import CliRunner
-
 from housekeeper.cli.add import file_cmd
 
 
@@ -89,6 +88,7 @@ def test_add_file_existing_bundle(
     case_id: str,
     second_sample_vcf: Path,
     caplog,
+    housekeeper_version_dir: Path,
 ):
     """Test to add a file to a existing bundle"""
     caplog.set_level(logging.DEBUG)
@@ -97,7 +97,9 @@ def test_add_file_existing_bundle(
 
     # WHEN trying to add the file to a bundle
     result = cli_runner.invoke(
-        file_cmd, [str(second_sample_vcf), "-b", bundle_name], obj=populated_context
+        file_cmd,
+        [str(second_sample_vcf), "-b", bundle_name],
+        obj=populated_context,
     )
 
     # THEN assert it succedes
@@ -110,6 +112,7 @@ def test_add_file_json(
     populated_context: Context,
     cli_runner: CliRunner,
     file_data_json: str,
+    housekeeper_version_dir: Path,
     caplog,
 ):
     """Test to add a file in json format to a non existing bundle"""

--- a/tests/cli/test_cli_include.py
+++ b/tests/cli/test_cli_include.py
@@ -1,18 +1,17 @@
 """Tests for include cli command"""
 import logging
 from datetime import datetime
+
 from click import Context
 from click.testing import CliRunner
-
-from housekeeper.cli.include import include
 from housekeeper.cli.add import bundle_cmd
+from housekeeper.cli.include import include
+from housekeeper.constants import ROOT
 from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle, Version
 
 
-def test_include_files_creates_bundle_dir(
-    populated_context: Context, cli_runner: CliRunner
-):
+def test_include_files_creates_bundle_dir(populated_context: Context, cli_runner: CliRunner):
     """Test to include the files of a version for a bundle_name
 
     The bundle should not exist before and after command is run it should have been created
@@ -24,7 +23,7 @@ def test_include_files_creates_bundle_dir(
     # GIVEN that the latest version of the bundle is not included
     assert bundle.versions[0].included_at is None
     # GIVEN that no folder has been created since case is not included
-    bundle_path = populated_context["root"] / bundle.name
+    bundle_path = populated_context[ROOT] / bundle.name
     assert not bundle_path.exists()
 
     # WHEN running the include files command
@@ -49,9 +48,7 @@ def test_include_files_creates_version_specific_bundle_dir(
     # GIVEN that the latest version of the bundle is not included
     assert version_obj.included_at is None
     # GIVEN that no version specific folder has been created since version is not included
-    version_path = (
-        populated_context["root"] / bundle.name / str(version_obj.created_at.date())
-    )
+    version_path = populated_context[ROOT] / bundle.name / str(version_obj.created_at.date())
     assert not version_path.exists()
 
     # WHEN running the include files command
@@ -76,9 +73,7 @@ def test_include_files_adds_version_specific_files(
     # GIVEN that the latest version of the bundle is not included
     assert version_obj.included_at is None
     # GIVEN that no version specific folder has been created since version is not included
-    version_path = (
-        populated_context["root"] / bundle.name / str(version_obj.created_at.date())
-    )
+    version_path = populated_context[ROOT] / bundle.name / str(version_obj.created_at.date())
     assert not version_path.exists()
 
     # WHEN running the include files command
@@ -93,9 +88,7 @@ def test_include_files_adds_version_specific_files(
     assert len(files_included) == len(version_obj.files)
 
 
-def test_include_files_specific_version(
-    populated_context: Context, cli_runner: CliRunner
-):
+def test_include_files_specific_version(populated_context: Context, cli_runner: CliRunner):
     """Test to include the files of a version by specifying the version id
 
     The folder should have been created
@@ -108,9 +101,7 @@ def test_include_files_specific_version(
     # GIVEN that the latest version of the bundle is not included
     assert version_obj.included_at is None
     # GIVEN that no version specific folder has been created since version is not included
-    version_path = (
-        populated_context["root"] / bundle.name / str(version_obj.created_at.date())
-    )
+    version_path = populated_context[ROOT] / bundle.name / str(version_obj.created_at.date())
     assert not version_path.exists()
 
     # WHEN running the include files command
@@ -128,9 +119,7 @@ def test_include_files_specific_version(
     assert len(files_included) == len(version_obj.files)
 
 
-def test_include_version_no_args(
-    populated_context: Context, cli_runner: CliRunner, caplog
-):
+def test_include_version_no_args(populated_context: Context, cli_runner: CliRunner, caplog):
     """Test to include the files of a version without specifying bundle name or version
 
     The command should exit since it needs to be specified
@@ -147,9 +136,7 @@ def test_include_version_no_args(
     assert "use bundle name or version-id" in caplog.text
 
 
-def test_include_non_existing_version(
-    populated_context: Context, cli_runner: CliRunner, caplog
-):
+def test_include_non_existing_version(populated_context: Context, cli_runner: CliRunner, caplog):
     """Test to include the files of a version that does not exist
 
     The command should exit since a valid version is needed
@@ -162,9 +149,7 @@ def test_include_non_existing_version(
     assert not store.get_version_by_id(version_id=version_id)
 
     # WHEN running the include files specifying the non existing version
-    result = cli_runner.invoke(
-        include, ["--version-id", version_id], obj=populated_context
-    )
+    result = cli_runner.invoke(include, ["--version-id", version_id], obj=populated_context)
 
     # THEN assert that the command exists with zero code 1
     assert result.exit_code == 1
@@ -234,14 +219,10 @@ def test_include_version_already_included(
     store: Store = populated_context["store"]
     version_obj = store._get_query(table=Version).first()
     version_id = version_obj.id
-    result = cli_runner.invoke(
-        include, ["--version-id", version_id], obj=populated_context
-    )
+    result = cli_runner.invoke(include, ["--version-id", version_id], obj=populated_context)
 
     # WHEN trying to include the version again
-    result = cli_runner.invoke(
-        include, ["--version-id", version_id], obj=populated_context
-    )
+    result = cli_runner.invoke(include, ["--version-id", version_id], obj=populated_context)
 
     # THEN assert that the command exists with zero code 1
     assert result.exit_code == 1

--- a/tests/cli/test_cli_include.py
+++ b/tests/cli/test_cli_include.py
@@ -49,7 +49,9 @@ def test_include_files_creates_version_specific_bundle_dir(
     # GIVEN that the latest version of the bundle is not included
     assert version_obj.included_at is None
     # GIVEN that no version specific folder has been created since version is not included
-    version_path = populated_context[ROOT] / bundle.name / str(version_obj.created_at.date())
+    version_path: Path = Path(
+        populated_context[ROOT], bundle.name, str(version_obj.created_at.date())
+    )
     assert not version_path.exists()
 
     # WHEN running the include files command

--- a/tests/cli/test_cli_include.py
+++ b/tests/cli/test_cli_include.py
@@ -1,6 +1,7 @@
 """Tests for include cli command"""
 import logging
 from datetime import datetime
+from pathlib import Path
 
 from click import Context
 from click.testing import CliRunner
@@ -23,7 +24,7 @@ def test_include_files_creates_bundle_dir(populated_context: Context, cli_runner
     # GIVEN that the latest version of the bundle is not included
     assert bundle.versions[0].included_at is None
     # GIVEN that no folder has been created since case is not included
-    bundle_path = populated_context[ROOT] / bundle.name
+    bundle_path = Path(populated_context[ROOT], bundle.name)
     assert not bundle_path.exists()
 
     # WHEN running the include files command
@@ -101,7 +102,9 @@ def test_include_files_specific_version(populated_context: Context, cli_runner: 
     # GIVEN that the latest version of the bundle is not included
     assert version_obj.included_at is None
     # GIVEN that no version specific folder has been created since version is not included
-    version_path = populated_context[ROOT] / bundle.name / str(version_obj.created_at.date())
+    version_path: Path = Path(
+        populated_context[ROOT], bundle.name, str(version_obj.created_at.date())
+    )
     assert not version_path.exists()
 
     # WHEN running the include files command

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -351,9 +351,9 @@ def fixture_project_dir(tmpdir_factory) -> Path:
 @pytest.fixture(scope="function", name="housekeeper_version_dir")
 def fixture_housekeeper_version_dir(project_dir, case_id, timestamp_string) -> Path:
     """Path to a created directory with case and version."""
-    my_tmpdir = Path(project_dir, case_id, timestamp_string)
-    my_tmpdir.mkdir(parents=True)
-    return my_tmpdir
+    hk_version_tmpdir: Path = Path(project_dir, case_id, timestamp_string)
+    hk_version_tmpdir.mkdir(parents=True)
+    return hk_version_tmpdir
 
 
 @pytest.fixture(scope="function", name="config_dir")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -349,7 +349,7 @@ def fixture_project_dir(tmpdir_factory) -> Path:
 
 
 @pytest.fixture(scope="function", name="housekeeper_version_dir")
-def fixture_housekeeper_version_dir(project_dir, case_id, timestamp_string) -> Path:
+def fixture_housekeeper_version_dir(project_dir: Path, case_id: str, timestamp_string: str) -> Path:
     """Path to a created directory with case and version."""
     hk_version_tmpdir: Path = Path(project_dir, case_id, timestamp_string)
     hk_version_tmpdir.mkdir(parents=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,11 @@ from typing import List
 
 import pytest
 import yaml
-
 from housekeeper.date import get_date
 from housekeeper.store import Store
 from housekeeper.store.models import Archive, Bundle, Tag, Version
 
 from .helper_functions import Helpers
-
 
 # basic fixtures
 
@@ -348,6 +346,14 @@ def fixture_project_dir(tmpdir_factory) -> Path:
     my_tmpdir = Path(tmpdir_factory.mktemp("workdir"))
     yield my_tmpdir
     shutil.rmtree(str(my_tmpdir))
+
+
+@pytest.fixture(scope="function", name="housekeeper_version_dir")
+def fixture_housekeeper_version_dir(project_dir, case_id, timestamp_string) -> Path:
+    """Path to a created directory with case and version"""
+    my_tmpdir = Path(project_dir, case_id, timestamp_string)
+    my_tmpdir.mkdir(parents=True)
+    return my_tmpdir
 
 
 @pytest.fixture(scope="function", name="config_dir")

--- a/tests/store/handlers/test_createhandler.py
+++ b/tests/store/handlers/test_createhandler.py
@@ -182,7 +182,6 @@ def test_add_file(
         file_path=second_family_vcf,
         bundle=bundle,
         tags=family_tag_names,
-        root=project_dir,
     )
 
     # THEN assert that the file is a file object
@@ -209,9 +208,7 @@ def test_add_file_no_tags(
     assert isinstance(bundle, Bundle)
 
     # WHEN using the add file method to create a new file object
-    new_file = populated_store.add_file(
-        file_path=second_family_vcf, bundle=bundle, root=project_dir
-    )
+    new_file = populated_store.add_file(file_path=second_family_vcf, bundle=bundle)
 
     # THEN assert that the no tags where added to the file
     assert len(new_file.tags) == 0

--- a/tests/store/handlers/test_createhandler.py
+++ b/tests/store/handlers/test_createhandler.py
@@ -3,11 +3,10 @@ from pathlib import Path
 from typing import List
 
 import pytest
-from sqlalchemy.exc import IntegrityError
-
 from housekeeper.store.api import schema
 from housekeeper.store.api.core import Store
-from housekeeper.store.models import Bundle, File, Tag, Version, Archive
+from housekeeper.store.models import Archive, Bundle, File, Tag, Version
+from sqlalchemy.exc import IntegrityError
 
 
 def test_schema_with_invalid_input(bundle_data_json):
@@ -164,7 +163,13 @@ def test_add_archive_to_archived_file(
         populated_store.session.commit()
 
 
-def test_add_file(populated_store: Store, second_family_vcf: Path, family_tag_names: List[str]):
+def test_add_file(
+    populated_store: Store,
+    second_family_vcf: Path,
+    family_tag_names: List[str],
+    housekeeper_version_dir: Path,
+    project_dir: Path,
+):
     """Test to create a file with the add file method."""
     # GIVEN the path and the tags for a file
 
@@ -174,7 +179,10 @@ def test_add_file(populated_store: Store, second_family_vcf: Path, family_tag_na
 
     # WHEN using the add file method to create a new file object
     new_file: File = populated_store.add_file(
-        file_path=second_family_vcf, bundle=bundle, tags=family_tag_names
+        file_path=second_family_vcf,
+        bundle=bundle,
+        tags=family_tag_names,
+        root=project_dir,
     )
 
     # THEN assert that the file is a file object
@@ -187,7 +195,12 @@ def test_add_file(populated_store: Store, second_family_vcf: Path, family_tag_na
         assert isinstance(tag_obj, Tag)
 
 
-def test_add_file_no_tags(populated_store: Store, second_family_vcf: Path):
+def test_add_file_no_tags(
+    populated_store: Store,
+    second_family_vcf: Path,
+    housekeeper_version_dir: Path,
+    project_dir: Path,
+):
     """Test to create a file with the add file method without tags."""
     # GIVEN a path for a file
 
@@ -196,7 +209,9 @@ def test_add_file_no_tags(populated_store: Store, second_family_vcf: Path):
     assert isinstance(bundle, Bundle)
 
     # WHEN using the add file method to create a new file object
-    new_file = populated_store.add_file(file_path=second_family_vcf, bundle=bundle)
+    new_file = populated_store.add_file(
+        file_path=second_family_vcf, bundle=bundle, root=project_dir
+    )
 
     # THEN assert that the no tags where added to the file
     assert len(new_file.tags) == 0


### PR DESCRIPTION
## Description

### Added

- Flag to indicate that the file should not be included in the housekeeper-bundles directory

## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b 115-include-file-when-adding```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
