### PR TITLE
Functionality for updating archiving/retrieval task ids

### DIFF
--- a/housekeeper/store/api/handlers/update.py
+++ b/housekeeper/store/api/handlers/update.py
@@ -58,7 +58,7 @@ class UpdateHandler(BaseHandler):
     @staticmethod
     def update_retrieval_task_id(archive: Archive, retrieval_task_id: int):
         """Sets the retrieval_task_id in the Archive entry for the provided file."""
-        archive.retrieval_task_id = retrieval_task_id
+        archive.retrieval_task_id: int = retrieval_task_id
 
     @staticmethod
     def update_archiving_task_id(archive: Archive, archiving_task_id: int):

--- a/housekeeper/store/api/handlers/update.py
+++ b/housekeeper/store/api/handlers/update.py
@@ -1,19 +1,14 @@
 """
 This module handles updating entries in the store/database.
 """
-from datetime import datetime
 import logging
+from datetime import datetime
 from typing import List
 
-from sqlalchemy.orm import Session
-
-
 from housekeeper.store.api.handlers.base import BaseHandler
-from housekeeper.store.filters.archive_filters import (
-    apply_archive_filter,
-    ArchiveFilter,
-)
-from housekeeper.store.models import Archive
+from housekeeper.store.filters.archive_filters import ArchiveFilter, apply_archive_filter
+from housekeeper.store.models import Archive, File
+from sqlalchemy.orm import Session
 
 LOG = logging.getLogger(__name__)
 
@@ -59,3 +54,17 @@ class UpdateHandler(BaseHandler):
         ).all()
         for archive in completed_archives:
             self.update_retrieval_time_stamp(archive=archive)
+
+    @staticmethod
+    def update_retrieval_task_id(file: File, retrieval_task_id: int):
+        """Sets the retrieval_task_id in the Archive entry for the provided file."""
+        archive: Archive = file.archive
+        if archive:
+            archive.retrieval_task_id = retrieval_task_id
+
+    @staticmethod
+    def update_archiving_task_id(file: File, archiving_task_id: int):
+        """Sets the archiving_task_id in the Archive entry for the provided file."""
+        archive: Archive = file.archive
+        if archive:
+            archive.archiving_task_id = archiving_task_id

--- a/housekeeper/store/api/handlers/update.py
+++ b/housekeeper/store/api/handlers/update.py
@@ -56,15 +56,11 @@ class UpdateHandler(BaseHandler):
             self.update_retrieval_time_stamp(archive=archive)
 
     @staticmethod
-    def update_retrieval_task_id(file: File, retrieval_task_id: int):
+    def update_retrieval_task_id(archive: Archive, retrieval_task_id: int):
         """Sets the retrieval_task_id in the Archive entry for the provided file."""
-        archive: Archive = file.archive
-        if archive:
-            archive.retrieval_task_id = retrieval_task_id
+        archive.retrieval_task_id = retrieval_task_id
 
     @staticmethod
-    def update_archiving_task_id(file: File, archiving_task_id: int):
+    def update_archiving_task_id(archive: Archive, archiving_task_id: int):
         """Sets the archiving_task_id in the Archive entry for the provided file."""
-        archive: Archive = file.archive
-        if archive:
-            archive.archiving_task_id = archiving_task_id
+        archive.archiving_task_id = archiving_task_id

--- a/housekeeper/store/api/handlers/update.py
+++ b/housekeeper/store/api/handlers/update.py
@@ -63,4 +63,4 @@ class UpdateHandler(BaseHandler):
     @staticmethod
     def update_archiving_task_id(archive: Archive, archiving_task_id: int):
         """Sets the archiving_task_id in the Archive entry for the provided file."""
-        archive.archiving_task_id = archiving_task_id
+        archive.archiving_task_id: int = archiving_task_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,12 @@ def fixture_archiving_task_id() -> int:
     return 1234
 
 
+@pytest.fixture(scope="function", name="new_archiving_task_id")
+def fixture_new_archiving_task_id() -> int:
+    """Return a new id of an archiving task."""
+    return 1235
+
+
 @pytest.fixture(scope="function", name="retrieval_task_id")
 def fixture_retrieval_task_id() -> int:
     """Return an id of a retrieval task."""

--- a/tests/store/handlers/test_updatehandler.py
+++ b/tests/store/handlers/test_updatehandler.py
@@ -103,7 +103,7 @@ def test_update_retrieval_task_id(archive: Archive, retrieval_task_id: int, popu
     assert not archive.retrieval_task_id
 
     # WHEN updating the retrieval task id
-    populated_store.update_retrieval_task_id(file=archive.file, retrieval_task_id=retrieval_task_id)
+    populated_store.update_retrieval_task_id(archive=archive, retrieval_task_id=retrieval_task_id)
 
     # THEN the retrieval task id should be set
     assert archive.retrieval_task_id == retrieval_task_id
@@ -119,7 +119,7 @@ def test_update_archiving_task_id(
 
     # WHEN updating the archiving_task_id
     populated_store.update_archiving_task_id(
-        file=archive.file, archiving_task_id=new_archiving_task_id
+        archive=archive, archiving_task_id=new_archiving_task_id
     )
 
     # THEN the retrieval task id should be set

--- a/tests/store/handlers/test_updatehandler.py
+++ b/tests/store/handlers/test_updatehandler.py
@@ -94,3 +94,32 @@ def test_update_finished_retrieval_task(
     assert archive.retrieved_at
     assert second_archive.retrieved_at
     assert archive.retrieved_at.minute == second_archive.retrieved_at.minute
+
+
+def test_update_retrieval_task_id(archive: Archive, retrieval_task_id: int, populated_store: store):
+    """Tests updating the retrieved_at timestamp on a given archive when there already is one."""
+    # GIVEN an Archive with no retrieval_task_id
+    assert not archive.retrieval_task_id
+
+    # WHEN updating the retrieval task id
+    populated_store.update_retrieval_task_id(file=archive.file, retrieval_task_id=retrieval_task_id)
+
+    # THEN the retrieval task id should be set
+    assert archive.retrieval_task_id == retrieval_task_id
+
+
+def test_update_archiving_task_id(
+    archive: Archive, new_archiving_task_id: int, populated_store: store
+):
+    """Tests updating the archiving_task_od on a given archive when there already is one.
+    Necessary for retrieval and rearchiving."""
+    # GIVEN an Archive with an old archiving_task_id
+    assert archive.archiving_task_id != new_archiving_task_id
+
+    # WHEN updating the archiving_task_id
+    populated_store.update_archiving_task_id(
+        file=archive.file, archiving_task_id=new_archiving_task_id
+    )
+
+    # THEN the retrieval task id should be set
+    assert archive.archiving_task_id == new_archiving_task_id

--- a/tests/store/handlers/test_updatehandler.py
+++ b/tests/store/handlers/test_updatehandler.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from housekeeper import store
 from housekeeper.store import Store
 from housekeeper.store.models import Archive


### PR DESCRIPTION
## Description

When retrieving archived files and rearchiving them, there is a need to update both the retrieval_task_id and archiving_task_id fields in the corresponding entry in the Archive table. This PR addresses that.

### Added

- Method update_retrieval_task_id.
- Method update_archiving_task_id.
- Tests for both methods.

## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b update_archive_entries```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
