### PR TITLE
Remove pytest fixture prefix snd name arg in decorator

### DIFF
--- a/tests/cli/add/conftest.py
+++ b/tests/cli/add/conftest.py
@@ -6,13 +6,13 @@ from typing import List
 import pytest
 
 
-@pytest.fixture(name="file_data")
-def fixture_file_data(second_sample_vcf: Path, case_id: str, sample_tag_names: List[str]) -> dict:
+@pytest.fixture()
+def file_data(second_sample_vcf: Path, case_id: str, sample_tag_names: List[str]) -> dict:
     """Return a dictionary with file information"""
     return {"path": str(second_sample_vcf), "tags": sample_tag_names, "bundle": case_id}
 
 
-@pytest.fixture(name="file_data_json")
-def fixture_file_data_json(file_data) -> str:
+@pytest.fixture()
+def file_data_json(file_data) -> str:
     """Return a json string with file information"""
     return json.dumps(file_data)

--- a/tests/cli/add/conftest.py
+++ b/tests/cli/add/conftest.py
@@ -6,13 +6,13 @@ from typing import List
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def file_data(second_sample_vcf: Path, case_id: str, sample_tag_names: List[str]) -> dict:
     """Return a dictionary with file information"""
     return {"path": str(second_sample_vcf), "tags": sample_tag_names, "bundle": case_id}
 
 
-@pytest.fixture()
+@pytest.fixture
 def file_data_json(file_data) -> str:
     """Return a json string with file information"""
     return json.dumps(file_data)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -7,7 +7,7 @@ from housekeeper.store import Store
 from tests.helper_functions import Helpers
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def store(project_dir, db_uri):
     """Override the store fixture to get a controlled db path"""
     _store = Store(uri=db_uri, root=str(project_dir))
@@ -16,13 +16,13 @@ def store(project_dir, db_uri):
     _store.drop_all()
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def cli_runner():
     """Return a cli runner for testing Click"""
     return CliRunner()
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def base_context(db_uri, project_dir, store) -> dict:
     """Return a context with initialized database"""
     return {
@@ -32,7 +32,7 @@ def base_context(db_uri, project_dir, store) -> dict:
     }
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def populated_context(db_uri, project_dir, populated_store) -> dict:
     """Return a context with initialized database with some data"""
     return {
@@ -42,7 +42,7 @@ def populated_context(db_uri, project_dir, populated_store) -> dict:
     }
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def populated_store_subsequent(
     store: Store, bundle_data_subsequent: dict, helpers: Helpers
 ) -> Store:
@@ -51,7 +51,7 @@ def populated_store_subsequent(
     return store
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def populated_context_subsequent(db_uri, project_dir, populated_store_subsequent):
     """Return a context with initialized database with some data"""
     return {
@@ -61,7 +61,7 @@ def populated_context_subsequent(db_uri, project_dir, populated_store_subsequent
     }
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def bundle_data_subsequent(
     case_id: str,
     family_data: dict,

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -7,8 +7,8 @@ from housekeeper.store import Store
 from tests.helper_functions import Helpers
 
 
-@pytest.fixture(scope="function", name="store")
-def fixture_store(project_dir, db_uri):
+@pytest.fixture(scope="function", )
+def store(project_dir, db_uri):
     """Override the store fixture to get a controlled db path"""
     _store = Store(uri=db_uri, root=str(project_dir))
     _store.create_all()
@@ -16,14 +16,14 @@ def fixture_store(project_dir, db_uri):
     _store.drop_all()
 
 
-@pytest.fixture(scope="function", name="cli_runner")
-def fixture_cli_runner():
+@pytest.fixture(scope="function", )
+def cli_runner():
     """Return a cli runner for testing Click"""
     return CliRunner()
 
 
-@pytest.fixture(scope="function", name="base_context")
-def fixture_base_context(db_uri, project_dir, store) -> dict:
+@pytest.fixture(scope="function", )
+def base_context(db_uri, project_dir, store) -> dict:
     """Return a context with initialized database"""
     return {
         "database": db_uri,
@@ -32,8 +32,8 @@ def fixture_base_context(db_uri, project_dir, store) -> dict:
     }
 
 
-@pytest.fixture(scope="function", name="populated_context")
-def fixture_populated_context(db_uri, project_dir, populated_store) -> dict:
+@pytest.fixture(scope="function", )
+def populated_context(db_uri, project_dir, populated_store) -> dict:
     """Return a context with initialized database with some data"""
     return {
         "database": db_uri,
@@ -42,8 +42,8 @@ def fixture_populated_context(db_uri, project_dir, populated_store) -> dict:
     }
 
 
-@pytest.fixture(scope="function", name="populated_store_subsequent")
-def fixture_populated_store_subsequent(
+@pytest.fixture(scope="function", )
+def populated_store_subsequent(
     store: Store, bundle_data_subsequent: dict, helpers: Helpers
 ) -> Store:
     """Returns a populated store"""
@@ -51,8 +51,8 @@ def fixture_populated_store_subsequent(
     return store
 
 
-@pytest.fixture(scope="function", name="populated_context_subsequent")
-def fixture_populated_context_subsequent(db_uri, project_dir, populated_store_subsequent):
+@pytest.fixture(scope="function", )
+def populated_context_subsequent(db_uri, project_dir, populated_store_subsequent):
     """Return a context with initialized database with some data"""
     return {
         "database": db_uri,
@@ -61,8 +61,8 @@ def fixture_populated_context_subsequent(db_uri, project_dir, populated_store_su
     }
 
 
-@pytest.fixture(scope="function", name="bundle_data_subsequent")
-def fixture_bundle_data_subsequent(
+@pytest.fixture(scope="function", )
+def bundle_data_subsequent(
     case_id: str,
     family_data: dict,
     family2_data: dict,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,152 +18,152 @@ from .helper_functions import Helpers
 # basic fixtures
 
 
-@pytest.fixture(scope="function", name="helpers")
-def fixture_helpers() -> Helpers:
+@pytest.fixture(scope="function", )
+def helpers() -> Helpers:
     """Return a test helper object."""
     return Helpers()
 
 
-@pytest.fixture(scope="function", name="vcf_tag_name")
-def fixture_vcf_tag_name() -> str:
+@pytest.fixture(scope="function", )
+def vcf_tag_name() -> str:
     """Return a tag named 'vcf'."""
     return "vcf"
 
 
-@pytest.fixture(scope="function", name="family_tag_name")
-def fixture_family_tag_name() -> str:
+@pytest.fixture(scope="function", )
+def family_tag_name() -> str:
     """Return a tag named 'family'."""
     return "family"
 
 
-@pytest.fixture(scope="function", name="sample_tag_name")
-def fixture_sample_tag_name() -> str:
+@pytest.fixture(scope="function", )
+def sample_tag_name() -> str:
     """Return a tag named 'sample'."""
     return "sample"
 
 
-@pytest.fixture(scope="function", name="non_existent_tag_name")
-def fixture_non_existent_tag_name() -> str:
+@pytest.fixture(scope="function", )
+def non_existent_tag_name() -> str:
     """Return a non-existent tag name."""
     return "not_a_tag_name"
 
 
-@pytest.fixture(scope="function", name="family_tag_names")
-def fixture_family_tag_names(vcf_tag_name: str, family_tag_name: str) -> List[str]:
+@pytest.fixture(scope="function", )
+def family_tag_names(vcf_tag_name: str, family_tag_name: str) -> List[str]:
     """Return a list of the family tag names."""
     return [vcf_tag_name, family_tag_name]
 
 
-@pytest.fixture(scope="function", name="sample_tag_names")
-def fixture_sample_tag_names(vcf_tag_name: str, sample_tag_name: str) -> List[str]:
+@pytest.fixture(scope="function", )
+def sample_tag_names(vcf_tag_name: str, sample_tag_name: str) -> List[str]:
     """Return a list of the sample tag names."""
     return [vcf_tag_name, sample_tag_name]
 
 
-@pytest.fixture(scope="function", name="spring_tag")
-def fixture_spring_tag() -> str:
+@pytest.fixture(scope="function", )
+def spring_tag() -> str:
     """Return the tag marking SPRING files."""
     return "spring"
 
 
-@pytest.fixture(scope="function", name="sample_id")
-def fixture_sample_id() -> str:
+@pytest.fixture(scope="function", )
+def sample_id() -> str:
     """Return name of a sample."""
     return "ACC123456A1"
 
 
-@pytest.fixture(scope="function", name="archiving_task_id")
-def fixture_archiving_task_id() -> int:
+@pytest.fixture(scope="function", )
+def archiving_task_id() -> int:
     """Return an id of an archiving task."""
     return 1234
 
 
-@pytest.fixture(scope="function", name="new_archiving_task_id")
-def fixture_new_archiving_task_id() -> int:
+@pytest.fixture(scope="function", )
+def new_archiving_task_id() -> int:
     """Return a new id of an archiving task."""
     return 1235
 
 
-@pytest.fixture(scope="function", name="retrieval_task_id")
-def fixture_retrieval_task_id() -> int:
+@pytest.fixture(scope="function", )
+def retrieval_task_id() -> int:
     """Return an id of a retrieval task."""
     return 4321
 
 
-@pytest.fixture(scope="function", name="case_id")
-def fixture_case_id() -> str:
+@pytest.fixture(scope="function", )
+def case_id() -> str:
     """Return name of a case."""
     return "handsomepig"
 
 
-@pytest.fixture(scope="function", name="other_case_id")
-def fixture_other_case_id() -> str:
+@pytest.fixture(scope="function", )
+def other_case_id() -> str:
     """Return name of a another case."""
     return "maturecogar"
 
 
-@pytest.fixture(scope="function", name="sample_data")
-def fixture_sample_data(sample_tag_names: List[str], sample_vcf: Path) -> dict:
+@pytest.fixture(scope="function", )
+def sample_data(sample_tag_names: List[str], sample_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": sample_tag_names, "file": sample_vcf}
 
 
-@pytest.fixture(scope="function", name="sample2_data")
-def fixture_sample2_data(sample_tag_names: List[str], second_sample_vcf: Path) -> dict:
+@pytest.fixture(scope="function", )
+def sample2_data(sample_tag_names: List[str], second_sample_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": sample_tag_names, "file": second_sample_vcf}
 
 
-@pytest.fixture(scope="function", name="spring_file_1_with_tags")
-def fixture_spring_file_1_with_tags(sample_id: str, spring_tag: str, spring_file_1: Path) -> dict:
+@pytest.fixture(scope="function", )
+def spring_file_1_with_tags(sample_id: str, spring_tag: str, spring_file_1: Path) -> dict:
     """Return spring file and tags for a sample."""
     return {"tags": [sample_id, spring_tag], "file": spring_file_1}
 
 
-@pytest.fixture(scope="function", name="spring_file_2_with_tags")
-def fixture_spring_file_2_with_tags(sample_id: str, spring_tag: str, spring_file_2: Path) -> dict:
+@pytest.fixture(scope="function", )
+def spring_file_2_with_tags(sample_id: str, spring_tag: str, spring_file_2: Path) -> dict:
     """Return a second SPRING file and tags for a sample."""
     return {"tags": [sample_id, spring_tag], "file": spring_file_2}
 
 
-@pytest.fixture(scope="function", name="family_data")
-def fixture_family_data(family_tag_names: List[str], family_vcf: Path) -> dict:
+@pytest.fixture(scope="function", )
+def family_data(family_tag_names: List[str], family_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": family_tag_names, "file": family_vcf}
 
 
-@pytest.fixture(scope="function", name="family2_data")
-def fixture_family2_data(family_tag_names: List[str], second_family_vcf: Path) -> dict:
+@pytest.fixture(scope="function", )
+def family2_data(family_tag_names: List[str], second_family_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": family_tag_names, "file": second_family_vcf}
 
 
-@pytest.fixture(scope="function", name="family3_data")
-def fixture_family3_data(family_tag_names: List[str], third_family_vcf: Path) -> dict:
+@pytest.fixture(scope="function", )
+def family3_data(family_tag_names: List[str], third_family_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": family_tag_names, "file": third_family_vcf}
 
 
-@pytest.fixture(scope="function", name="timestamp_string")
-def fixture_timestamp_string() -> str:
+@pytest.fixture(scope="function", )
+def timestamp_string() -> str:
     """Return a time stamp in str format."""
     return "2020-05-01"
 
 
-@pytest.fixture(scope="function", name="timestamp")
-def fixture_timestamp(timestamp_string: str) -> datetime.datetime:
+@pytest.fixture(scope="function", )
+def timestamp(timestamp_string: str) -> datetime.datetime:
     """Return a time stamp in date time format."""
     return get_date(timestamp_string)
 
 
-@pytest.fixture(scope="function", name="later_timestamp")
-def fixture_later_timestamp() -> datetime.datetime:
+@pytest.fixture(scope="function", )
+def later_timestamp() -> datetime.datetime:
     """Return a time stamp in date time format to a later date."""
     return datetime.datetime(2020, 5, 25)
 
 
-@pytest.fixture(scope="function", name="bundle_data")
-def fixture_bundle_data(
+@pytest.fixture(scope="function", )
+def bundle_data(
     case_id: str,
     sample_data: dict,
     family_data: dict,
@@ -177,8 +177,8 @@ def fixture_bundle_data(
     return data
 
 
-@pytest.fixture(scope="function", name="sample_bundle_data")
-def fixture_sample_bundle_data(
+@pytest.fixture(scope="function", )
+def sample_bundle_data(
     sample_id: str,
     sample_data: dict,
     spring_file_1_with_tags: dict,
@@ -194,15 +194,15 @@ def fixture_sample_bundle_data(
     )
 
 
-@pytest.fixture(scope="function", name="empty_version_data")
-def fixture_empty_version_data(later_timestamp: datetime.datetime, case_id: str) -> dict:
+@pytest.fixture(scope="function", )
+def empty_version_data(later_timestamp: datetime.datetime, case_id: str) -> dict:
     """Return a dummy bundle."""
     data = {"bundle_name": case_id, "created_at": later_timestamp, "files": []}
     return data
 
 
-@pytest.fixture(scope="function", name="version_data")
-def fixture_version_data(empty_version_data: dict, family2_data: dict, sample2_data: dict) -> dict:
+@pytest.fixture(scope="function", )
+def version_data(empty_version_data: dict, family2_data: dict, sample2_data: dict) -> dict:
     """Return a dummy bundle."""
     data = copy.deepcopy(empty_version_data)
     data["files"] = [
@@ -220,32 +220,32 @@ def fixture_version_data(empty_version_data: dict, family2_data: dict, sample2_d
     return data
 
 
-@pytest.fixture(scope="function", name="bundle_data_json")
-def fixture_bundle_data_json(bundle_data: dict) -> str:
+@pytest.fixture(scope="function", )
+def bundle_data_json(bundle_data: dict) -> str:
     """Return a dummy bundle."""
     json_data = copy.deepcopy(bundle_data)
     json_data["created_at"] = str(json_data.pop("created_at"))
     return json.dumps(json_data)
 
 
-@pytest.fixture(scope="function", name="empty_version_data_json")
-def fixture_empty_version_data_json(empty_version_data: dict) -> str:
+@pytest.fixture(scope="function", )
+def empty_version_data_json(empty_version_data: dict) -> str:
     """Return a dummy bundle."""
     json_data = copy.deepcopy(empty_version_data)
     json_data["created_at"] = str(json_data.pop("created_at"))
     return json.dumps(json_data)
 
 
-@pytest.fixture(scope="function", name="version_data_json")
-def fixture_version_data_json(version_data: dict) -> str:
+@pytest.fixture(scope="function", )
+def version_data_json(version_data: dict) -> str:
     """Return a dummy bundle."""
     json_data = copy.deepcopy(version_data)
     json_data["created_at"] = str(json_data.pop("created_at"))
     return json.dumps(json_data)
 
 
-@pytest.fixture(scope="function", name="other_bundle")
-def fixture_other_bundle(
+@pytest.fixture(scope="function", )
+def other_bundle(
     bundle_data: dict,
     other_case_id: str,
     later_timestamp: datetime.datetime,
@@ -261,32 +261,32 @@ def fixture_other_bundle(
     return data
 
 
-@pytest.fixture(scope="function", name="db_name")
-def fixture_db_name() -> str:
+@pytest.fixture(scope="function", )
+def db_name() -> str:
     """Return the name of a database."""
     return "hk_test.db"
 
 
-@pytest.fixture(scope="function", name="db_path")
-def fixture_db_path(db_dir: Path, db_name: str) -> Path:
+@pytest.fixture(scope="function", )
+def db_path(db_dir: Path, db_name: str) -> Path:
     """Return the path to a database."""
     return db_dir / db_name
 
 
-@pytest.fixture(scope="function", name="db_uri")
-def fixture_db_uri(db_path: Path) -> str:
+@pytest.fixture(scope="function", )
+def db_uri(db_path: Path) -> str:
     """Return the uri to an in memory database."""
     return "sqlite:///" + str(db_path)
 
 
-@pytest.fixture(scope="function", name="db_uri_memory")
-def fixture_db_uri_memory() -> str:
+@pytest.fixture(scope="function", )
+def db_uri_memory() -> str:
     """Return the uri to an in memory database."""
     return "sqlite:///:memory:"
 
 
-@pytest.fixture(scope="function", name="configs")
-def fixture_configs(project_dir: Path, db_uri: str) -> dict:
+@pytest.fixture(scope="function", )
+def configs(project_dir: Path, db_uri: str) -> dict:
     """Return a dict with housekeeper configs."""
     _configs = {"root": str(project_dir), "database": db_uri}
     return _configs
@@ -295,32 +295,32 @@ def fixture_configs(project_dir: Path, db_uri: str) -> dict:
 # object fixtures
 
 
-@pytest.fixture(scope="function", name="vcf_tag_obj")
-def fixture_vcf_tag_obj(vcf_tag_name: str, timestamp: datetime.datetime) -> str:
+@pytest.fixture(scope="function", )
+def vcf_tag_obj(vcf_tag_name: str, timestamp: datetime.datetime) -> str:
     """Return a tag object."""
     return Tag(name=vcf_tag_name, created_at=timestamp)
 
 
-@pytest.fixture(scope="function", name="bundle_obj")
-def fixture_bundle_obj(bundle_data: dict, store: Store) -> Bundle:
+@pytest.fixture(scope="function", )
+def bundle_obj(bundle_data: dict, store: Store) -> Bundle:
     """Return a bundle object."""
     return store.add_bundle(bundle_data)[0]
 
 
-@pytest.fixture(scope="function", name="sample_bundle")
-def fixture_sample_bundle(sample_bundle_data: dict, store: Store) -> Bundle:
+@pytest.fixture(scope="function", )
+def sample_bundle(sample_bundle_data: dict, store: Store) -> Bundle:
     """Return a bundle object."""
     return store.add_bundle(sample_bundle_data)[0]
 
 
-@pytest.fixture(scope="function", name="version_obj")
-def fixture_version_obj(bundle_data: dict, store: Store) -> Version:
+@pytest.fixture(scope="function", )
+def version_obj(bundle_data: dict, store: Store) -> Version:
     """Return a version object."""
     return store.add_bundle(bundle_data)[1]
 
 
-@pytest.fixture(scope="function", name="archive")
-def fixture_archive(populated_store: Store) -> Archive:
+@pytest.fixture(scope="function", )
+def archive(populated_store: Store) -> Archive:
     """Return an archive object."""
     return populated_store._get_query(table=Archive).first()
 
@@ -328,50 +328,50 @@ def fixture_archive(populated_store: Store) -> Archive:
 # dir fixtures
 
 
-@pytest.fixture(scope="function", name="fixtures_dir")
-def fixture_fixtures_dir() -> Path:
+@pytest.fixture(scope="function", )
+def fixtures_dir() -> Path:
     """Return the path to the fixtures directory."""
     return Path("tests/fixtures/")
 
 
-@pytest.fixture(scope="function", name="vcf_dir")
-def fixture_vcf_dir(fixtures_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def vcf_dir(fixtures_dir: Path) -> Path:
     """Return the path to the vcf fixtures directory."""
     return fixtures_dir / "vcfs"
 
 
-@pytest.fixture(scope="function", name="sequencing_files_dir")
-def fixture_sequencing_files_dir(fixtures_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def sequencing_files_dir(fixtures_dir: Path) -> Path:
     """Return the path to the sequencing_files fixtures directory."""
     return Path(fixtures_dir, "sequencing_files")
 
 
-@pytest.fixture(scope="function", name="project_dir")
-def fixture_project_dir(tmpdir_factory) -> Path:
+@pytest.fixture(scope="function", )
+def project_dir(tmpdir_factory) -> Path:
     """Path to a temporary working directory."""
     my_tmpdir = Path(tmpdir_factory.mktemp("workdir"))
     yield my_tmpdir
     shutil.rmtree(str(my_tmpdir))
 
 
-@pytest.fixture(scope="function", name="housekeeper_version_dir")
-def fixture_housekeeper_version_dir(project_dir: Path, case_id: str, timestamp_string: str) -> Path:
+@pytest.fixture(scope="function", )
+def housekeeper_version_dir(project_dir: Path, case_id: str, timestamp_string: str) -> Path:
     """Path to a created directory with case and version."""
     hk_version_tmpdir: Path = Path(project_dir, case_id, timestamp_string)
     hk_version_tmpdir.mkdir(parents=True)
     return hk_version_tmpdir
 
 
-@pytest.fixture(scope="function", name="config_dir")
-def fixture_config_dir(tmpdir_factory) -> Path:
+@pytest.fixture(scope="function", )
+def config_dir(tmpdir_factory) -> Path:
     """Path to a temporary directory for config files."""
     my_tmpdir = Path(tmpdir_factory.mktemp("confdir"))
     yield my_tmpdir
     shutil.rmtree(str(my_tmpdir))
 
 
-@pytest.fixture(scope="function", name="db_dir")
-def fixture_db_dir(tmpdir_factory) -> Path:
+@pytest.fixture(scope="function", )
+def db_dir(tmpdir_factory) -> Path:
     """Path to a temporary directory for databases."""
     my_tmpdir = Path(tmpdir_factory.mktemp("db_dir"))
     yield my_tmpdir
@@ -381,8 +381,8 @@ def fixture_db_dir(tmpdir_factory) -> Path:
 # File fixtures
 
 
-@pytest.fixture(scope="function", name="config_file")
-def fixture_config_file(config_dir: Path, configs: dict) -> Path:
+@pytest.fixture(scope="function", )
+def config_file(config_dir: Path, configs: dict) -> Path:
     """Create a config file and return the path to it."""
     conf_path = config_dir / "config.json"
     with open(conf_path, "w") as out_file:
@@ -390,80 +390,80 @@ def fixture_config_file(config_dir: Path, configs: dict) -> Path:
     return conf_path
 
 
-@pytest.fixture(scope="function", name="sample_vcf")
-def fixture_sample_vcf(vcf_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def sample_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "example.vcf")
 
 
-@pytest.fixture(scope="function", name="spring_file_1")
-def fixture_spring_file_1(sequencing_files_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def spring_file_1(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane1.spring")
 
 
-@pytest.fixture(scope="function", name="spring_file_2")
-def fixture_spring_file_2(sequencing_files_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def spring_file_2(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane2.spring")
 
 
-@pytest.fixture(scope="function", name="archived_file")
-def fixture_archived_file(spring_file_1: Path) -> Path:
+@pytest.fixture(scope="function", )
+def archived_file(spring_file_1: Path) -> Path:
     """Return the path to an archived file."""
     return spring_file_1
 
 
-@pytest.fixture(scope="function", name="non_archived_file")
-def fixture_non_archived_file(spring_file_2: Path) -> Path:
+@pytest.fixture(scope="function", )
+def non_archived_file(spring_file_2: Path) -> Path:
     """Return the path to a non-archived file."""
     return spring_file_2
 
 
-@pytest.fixture(scope="function", name="spring_file_2")
-def fixture_spring_file_2(sequencing_files_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def spring_file_2(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane2.spring")
 
 
-@pytest.fixture(scope="function", name="family_vcf")
-def fixture_family_vcf(vcf_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "family.vcf")
 
 
-@pytest.fixture(scope="function", name="second_sample_vcf")
-def fixture_second_sample_vcf(vcf_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def second_sample_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "example.2.vcf")
 
 
-@pytest.fixture(scope="function", name="second_family_vcf")
-def fixture_second_family_vcf(vcf_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def second_family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "family.2.vcf")
 
 
-@pytest.fixture(scope="function", name="third_family_vcf")
-def fixture_third_family_vcf(vcf_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def third_family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "family.3.vcf")
 
 
-@pytest.fixture(scope="function", name="checksum_file")
-def fixture_checksum_file(fixtures_dir: Path) -> Path:
+@pytest.fixture(scope="function", )
+def checksum_file(fixtures_dir: Path) -> Path:
     """Return the path to file to test checksum."""
     return Path(fixtures_dir, "26a90105b99c05381328317f913e9509e373b64f.txt")
 
 
-@pytest.fixture(scope="function", name="checksum")
-def fixture_checksum(checksum_file: Path) -> Path:
+@pytest.fixture(scope="function", )
+def checksum(checksum_file: Path) -> Path:
     """Return the checksum for checksum test file."""
     return checksum_file.name.rstrip(".txt")
 
 
-@pytest.fixture(scope="function", name="helpers")
-def fixture_helpers() -> Helpers:
+@pytest.fixture(scope="function", )
+def helpers() -> Helpers:
     """Return a test helper object."""
     return Helpers()
 
@@ -471,8 +471,8 @@ def fixture_helpers() -> Helpers:
 # Store fixtures
 
 
-@pytest.fixture(scope="function", name="store")
-def fixture_store(project_dir: Path) -> Store:
+@pytest.fixture(scope="function", )
+def store(project_dir: Path) -> Store:
     """Return a store setup with all tables."""
     _store = Store(uri="sqlite:///", root=str(project_dir))
     _store.create_all()
@@ -480,8 +480,8 @@ def fixture_store(project_dir: Path) -> Store:
     _store.drop_all()
 
 
-@pytest.fixture(scope="function", name="populated_store")
-def fixture_populated_store(
+@pytest.fixture(scope="function", )
+def populated_store(
     archiving_task_id: int,
     bundle_data: dict,
     helpers: Helpers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,151 +18,151 @@ from .helper_functions import Helpers
 # basic fixtures
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def helpers() -> Helpers:
     """Return a test helper object."""
     return Helpers()
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def vcf_tag_name() -> str:
     """Return a tag named 'vcf'."""
     return "vcf"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def family_tag_name() -> str:
     """Return a tag named 'family'."""
     return "family"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_tag_name() -> str:
     """Return a tag named 'sample'."""
     return "sample"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def non_existent_tag_name() -> str:
     """Return a non-existent tag name."""
     return "not_a_tag_name"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def family_tag_names(vcf_tag_name: str, family_tag_name: str) -> List[str]:
     """Return a list of the family tag names."""
     return [vcf_tag_name, family_tag_name]
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_tag_names(vcf_tag_name: str, sample_tag_name: str) -> List[str]:
     """Return a list of the sample tag names."""
     return [vcf_tag_name, sample_tag_name]
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def spring_tag() -> str:
     """Return the tag marking SPRING files."""
     return "spring"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_id() -> str:
     """Return name of a sample."""
     return "ACC123456A1"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def archiving_task_id() -> int:
     """Return an id of an archiving task."""
     return 1234
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def new_archiving_task_id() -> int:
     """Return a new id of an archiving task."""
     return 1235
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def retrieval_task_id() -> int:
     """Return an id of a retrieval task."""
     return 4321
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def case_id() -> str:
     """Return name of a case."""
     return "handsomepig"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def other_case_id() -> str:
     """Return name of a another case."""
     return "maturecogar"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_data(sample_tag_names: List[str], sample_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": sample_tag_names, "file": sample_vcf}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample2_data(sample_tag_names: List[str], second_sample_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": sample_tag_names, "file": second_sample_vcf}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def spring_file_1_with_tags(sample_id: str, spring_tag: str, spring_file_1: Path) -> dict:
     """Return spring file and tags for a sample."""
     return {"tags": [sample_id, spring_tag], "file": spring_file_1}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def spring_file_2_with_tags(sample_id: str, spring_tag: str, spring_file_2: Path) -> dict:
     """Return a second SPRING file and tags for a sample."""
     return {"tags": [sample_id, spring_tag], "file": spring_file_2}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def family_data(family_tag_names: List[str], family_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": family_tag_names, "file": family_vcf}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def family2_data(family_tag_names: List[str], second_family_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": family_tag_names, "file": second_family_vcf}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def family3_data(family_tag_names: List[str], third_family_vcf: Path) -> dict:
     """Return file and tags for sample."""
     return {"tags": family_tag_names, "file": third_family_vcf}
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def timestamp_string() -> str:
     """Return a time stamp in str format."""
     return "2020-05-01"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def timestamp(timestamp_string: str) -> datetime.datetime:
     """Return a time stamp in date time format."""
     return get_date(timestamp_string)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def later_timestamp() -> datetime.datetime:
     """Return a time stamp in date time format to a later date."""
     return datetime.datetime(2020, 5, 25)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def bundle_data(
     case_id: str,
     sample_data: dict,
@@ -177,7 +177,7 @@ def bundle_data(
     return data
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_bundle_data(
     sample_id: str,
     sample_data: dict,
@@ -194,14 +194,14 @@ def sample_bundle_data(
     )
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def empty_version_data(later_timestamp: datetime.datetime, case_id: str) -> dict:
     """Return a dummy bundle."""
     data = {"bundle_name": case_id, "created_at": later_timestamp, "files": []}
     return data
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def version_data(empty_version_data: dict, family2_data: dict, sample2_data: dict) -> dict:
     """Return a dummy bundle."""
     data = copy.deepcopy(empty_version_data)
@@ -220,7 +220,7 @@ def version_data(empty_version_data: dict, family2_data: dict, sample2_data: dic
     return data
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def bundle_data_json(bundle_data: dict) -> str:
     """Return a dummy bundle."""
     json_data = copy.deepcopy(bundle_data)
@@ -228,7 +228,7 @@ def bundle_data_json(bundle_data: dict) -> str:
     return json.dumps(json_data)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def empty_version_data_json(empty_version_data: dict) -> str:
     """Return a dummy bundle."""
     json_data = copy.deepcopy(empty_version_data)
@@ -236,7 +236,7 @@ def empty_version_data_json(empty_version_data: dict) -> str:
     return json.dumps(json_data)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def version_data_json(version_data: dict) -> str:
     """Return a dummy bundle."""
     json_data = copy.deepcopy(version_data)
@@ -244,7 +244,7 @@ def version_data_json(version_data: dict) -> str:
     return json.dumps(json_data)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def other_bundle(
     bundle_data: dict,
     other_case_id: str,
@@ -261,31 +261,31 @@ def other_bundle(
     return data
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def db_name() -> str:
     """Return the name of a database."""
     return "hk_test.db"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def db_path(db_dir: Path, db_name: str) -> Path:
     """Return the path to a database."""
     return db_dir / db_name
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def db_uri(db_path: Path) -> str:
     """Return the uri to an in memory database."""
     return "sqlite:///" + str(db_path)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def db_uri_memory() -> str:
     """Return the uri to an in memory database."""
     return "sqlite:///:memory:"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def configs(project_dir: Path, db_uri: str) -> dict:
     """Return a dict with housekeeper configs."""
     _configs = {"root": str(project_dir), "database": db_uri}
@@ -295,31 +295,31 @@ def configs(project_dir: Path, db_uri: str) -> dict:
 # object fixtures
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def vcf_tag_obj(vcf_tag_name: str, timestamp: datetime.datetime) -> str:
     """Return a tag object."""
     return Tag(name=vcf_tag_name, created_at=timestamp)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def bundle_obj(bundle_data: dict, store: Store) -> Bundle:
     """Return a bundle object."""
     return store.add_bundle(bundle_data)[0]
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_bundle(sample_bundle_data: dict, store: Store) -> Bundle:
     """Return a bundle object."""
     return store.add_bundle(sample_bundle_data)[0]
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def version_obj(bundle_data: dict, store: Store) -> Version:
     """Return a version object."""
     return store.add_bundle(bundle_data)[1]
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def archive(populated_store: Store) -> Archive:
     """Return an archive object."""
     return populated_store._get_query(table=Archive).first()
@@ -328,25 +328,25 @@ def archive(populated_store: Store) -> Archive:
 # dir fixtures
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def fixtures_dir() -> Path:
     """Return the path to the fixtures directory."""
     return Path("tests/fixtures/")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def vcf_dir(fixtures_dir: Path) -> Path:
     """Return the path to the vcf fixtures directory."""
     return fixtures_dir / "vcfs"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sequencing_files_dir(fixtures_dir: Path) -> Path:
     """Return the path to the sequencing_files fixtures directory."""
     return Path(fixtures_dir, "sequencing_files")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def project_dir(tmpdir_factory) -> Path:
     """Path to a temporary working directory."""
     my_tmpdir = Path(tmpdir_factory.mktemp("workdir"))
@@ -354,7 +354,7 @@ def project_dir(tmpdir_factory) -> Path:
     shutil.rmtree(str(my_tmpdir))
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def housekeeper_version_dir(project_dir: Path, case_id: str, timestamp_string: str) -> Path:
     """Path to a created directory with case and version."""
     hk_version_tmpdir: Path = Path(project_dir, case_id, timestamp_string)
@@ -362,7 +362,7 @@ def housekeeper_version_dir(project_dir: Path, case_id: str, timestamp_string: s
     return hk_version_tmpdir
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def config_dir(tmpdir_factory) -> Path:
     """Path to a temporary directory for config files."""
     my_tmpdir = Path(tmpdir_factory.mktemp("confdir"))
@@ -370,7 +370,7 @@ def config_dir(tmpdir_factory) -> Path:
     shutil.rmtree(str(my_tmpdir))
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def db_dir(tmpdir_factory) -> Path:
     """Path to a temporary directory for databases."""
     my_tmpdir = Path(tmpdir_factory.mktemp("db_dir"))
@@ -381,7 +381,7 @@ def db_dir(tmpdir_factory) -> Path:
 # File fixtures
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def config_file(config_dir: Path, configs: dict) -> Path:
     """Create a config file and return the path to it."""
     conf_path = config_dir / "config.json"
@@ -390,79 +390,79 @@ def config_file(config_dir: Path, configs: dict) -> Path:
     return conf_path
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def sample_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "example.vcf")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def spring_file_1(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane1.spring")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def spring_file_2(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane2.spring")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def archived_file(spring_file_1: Path) -> Path:
     """Return the path to an archived file."""
     return spring_file_1
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def non_archived_file(spring_file_2: Path) -> Path:
     """Return the path to a non-archived file."""
     return spring_file_2
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def spring_file_2(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane2.spring")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "family.vcf")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def second_sample_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "example.2.vcf")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def second_family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "family.2.vcf")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def third_family_vcf(vcf_dir: Path) -> Path:
     """Return the path to a vcf file."""
     return Path(vcf_dir, "family.3.vcf")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def checksum_file(fixtures_dir: Path) -> Path:
     """Return the path to file to test checksum."""
     return Path(fixtures_dir, "26a90105b99c05381328317f913e9509e373b64f.txt")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def checksum(checksum_file: Path) -> Path:
     """Return the checksum for checksum test file."""
     return checksum_file.name.rstrip(".txt")
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def helpers() -> Helpers:
     """Return a test helper object."""
     return Helpers()
@@ -471,7 +471,7 @@ def helpers() -> Helpers:
 # Store fixtures
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def store(project_dir: Path) -> Store:
     """Return a store setup with all tables."""
     _store = Store(uri="sqlite:///", root=str(project_dir))
@@ -480,7 +480,7 @@ def store(project_dir: Path) -> Store:
     _store.drop_all()
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def populated_store(
     archiving_task_id: int,
     bundle_data: dict,

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from housekeeper.store import models
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def minimal_bundle_obj(case_id, timestamp) -> models.Bundle:
     """Return a bundle object"""
     return models.Bundle(name=case_id, created_at=timestamp)
@@ -22,19 +22,19 @@ def bundle_data_json(bundle_data):
     return json_data
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def second_timestamp(timestamp) -> datetime.datetime:
     """Return a time stamp in date time format"""
     return timestamp + datetime.timedelta(days=10)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def old_timestamp() -> datetime.datetime:
     """Return a time stamp that is older than a year"""
     return datetime.datetime(2018, 1, 1)
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def second_bundle_data(
     bundle_data, second_sample_vcf, second_family_vcf, second_timestamp
 ) -> dict:
@@ -46,13 +46,13 @@ def second_bundle_data(
     return second_bundle
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def other_case() -> str:
     """Return the case id that differs from base fixture"""
     return "angrybird"
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def bundle_data_old(
     bundle_data, second_sample_vcf, second_family_vcf, old_timestamp, other_case
 ) -> dict:
@@ -65,7 +65,7 @@ def bundle_data_old(
     return _bundle
 
 
-@pytest.fixture(scope="function", )
+@pytest.fixture(scope="function")
 def time_stamp_now() -> dt.datetime:
     """Time stamp now"""
     return dt.datetime.now()

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -8,8 +8,8 @@ import pytest
 from housekeeper.store import models
 
 
-@pytest.fixture(scope="function", name="minimal_bundle_obj")
-def fixture_minimal_bundle_obj(case_id, timestamp) -> models.Bundle:
+@pytest.fixture(scope="function", )
+def minimal_bundle_obj(case_id, timestamp) -> models.Bundle:
     """Return a bundle object"""
     return models.Bundle(name=case_id, created_at=timestamp)
 
@@ -22,20 +22,20 @@ def bundle_data_json(bundle_data):
     return json_data
 
 
-@pytest.fixture(scope="function", name="second_timestamp")
-def fixture_second_timestamp(timestamp) -> datetime.datetime:
+@pytest.fixture(scope="function", )
+def second_timestamp(timestamp) -> datetime.datetime:
     """Return a time stamp in date time format"""
     return timestamp + datetime.timedelta(days=10)
 
 
-@pytest.fixture(scope="function", name="old_timestamp")
-def fixture_old_timestamp() -> datetime.datetime:
+@pytest.fixture(scope="function", )
+def old_timestamp() -> datetime.datetime:
     """Return a time stamp that is older than a year"""
     return datetime.datetime(2018, 1, 1)
 
 
-@pytest.fixture(scope="function", name="second_bundle_data")
-def fixture_second_bundle_data(
+@pytest.fixture(scope="function", )
+def second_bundle_data(
     bundle_data, second_sample_vcf, second_family_vcf, second_timestamp
 ) -> dict:
     """Return a bundle similar to bundle_data with updated file paths"""
@@ -46,13 +46,13 @@ def fixture_second_bundle_data(
     return second_bundle
 
 
-@pytest.fixture(scope="function", name="other_case")
-def fixture_other_case() -> str:
+@pytest.fixture(scope="function", )
+def other_case() -> str:
     """Return the case id that differs from base fixture"""
     return "angrybird"
 
 
-@pytest.fixture(scope="function", name="bundle_data_old")
+@pytest.fixture(scope="function", )
 def bundle_data_old(
     bundle_data, second_sample_vcf, second_family_vcf, old_timestamp, other_case
 ) -> dict:
@@ -65,7 +65,7 @@ def bundle_data_old(
     return _bundle
 
 
-@pytest.fixture(scope="function", name="time_stamp_now")
+@pytest.fixture(scope="function", )
 def time_stamp_now() -> dt.datetime:
     """Time stamp now"""
     return dt.datetime.now()


### PR DESCRIPTION
## Description

Remove pytest fixture prefix snd name arg in decorator

### Changed

- Remove pytest fixture prefix snd name arg in decorator

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b YOURBRANCH```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
