### PR TITLE
Include bundle by default

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -8,8 +8,9 @@ from typing import Dict, Generator, List
 import click
 from housekeeper.constants import ROOT
 from housekeeper.date import get_date
+from housekeeper.exc import VersionIncludedError
 from housekeeper.files import load_json, validate_input
-from housekeeper.include import link_to_relative_path, relative_path
+from housekeeper.include import include_version, link_to_relative_path, relative_path
 from housekeeper.store import Store
 from housekeeper.store.models import Bundle, Tag, Version
 
@@ -38,8 +39,9 @@ def add():
 @add.command("bundle")
 @click.argument("bundle_name", required=False)
 @click.option("-j", "--json", help="Input json string")
+@click.option("-e", "--exclude", help="Use to not include bundle when adding it.", is_flag=True)
 @click.pass_context
-def bundle_cmd(context: click.Context, bundle_name: str, json: str):
+def bundle_cmd(context: click.Context, bundle_name: str, json: str, exclude: bool):
     """Add a new bundle."""
     LOG.info("Running add bundle")
     store: Store = context.obj["store"]
@@ -70,6 +72,13 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str):
     store.session.add(new_bundle)
     new_version.bundle: Bundle = new_bundle
     store.session.add(new_version)
+    if not exclude:
+        try:
+            include_version(context.obj[ROOT], new_version)
+        except VersionIncludedError as error:
+            LOG.warning(error.message)
+            raise click.Abort
+        new_version.included_at = dt.datetime.now()
     store.session.commit()
     LOG.info("new bundle added: %s (%s)", new_bundle.name, new_bundle.id)
 

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -74,9 +74,10 @@ def bundle_cmd(context: click.Context, bundle_name: str, json: str, exclude: boo
     store.session.add(new_version)
     if not exclude:
         try:
-            include_version(context.obj[ROOT], new_version)
+            context_root_dir: str = context.obj[ROOT]
+            include_version(global_root=context_root_dir, version_obj=new_version)
         except VersionIncludedError as error:
-            LOG.warning(error.message)
+            LOG.error(error.message)
             raise click.Abort
         new_version.included_at = dt.datetime.now()
     store.session.commit()

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -35,9 +35,7 @@ def old_timestamp() -> datetime.datetime:
 
 
 @pytest.fixture(scope="function")
-def second_bundle_data(
-    bundle_data, second_sample_vcf, second_family_vcf, second_timestamp
-) -> dict:
+def second_bundle_data(bundle_data, second_sample_vcf, second_family_vcf, second_timestamp) -> dict:
     """Return a bundle similar to bundle_data with updated file paths"""
     second_bundle = deepcopy(bundle_data)
     second_bundle["created_at"] = second_timestamp


### PR DESCRIPTION
## Description

Addresses issue #136 and adds an exclude flag to the add command. If not used, the add bundle command will include the bundle.

### Added

- Flag to exclude bundle when running `housekeeper add bundle`.

### Changed

- By default `housekeeper add bundle` includes the bundle.

## Testing

### How to prepare for test

- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b include-bundle-by-default```

### How to test
- [x] Add a bundle
- [x] Add a file to the bundle

### Expected test outcome
- [x] Check that the bundle was added and included.
- [x] Check that adding the file works without running `include bundle`.
- [x] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
