### PR TITLE
Upgrade sqlalchemy to 1.4

### DIFF
--- a/housekeeper/cli/init.py
+++ b/housekeeper/cli/init.py
@@ -28,4 +28,4 @@ def init(context, reset, force):
         context.abort()
 
     store.create_all()
-    LOG.info("Success! New tables: %s", ", ".join(inspector.get_table_names()))
+    LOG.info(f"Success! New tables: {', '.join(inspector.get_table_names())}")

--- a/housekeeper/cli/init.py
+++ b/housekeeper/cli/init.py
@@ -2,6 +2,8 @@
 import logging
 import click
 from housekeeper.store.api.core import Store
+from sqlalchemy import inspect
+
 
 LOG = logging.getLogger(__name__)
 
@@ -13,7 +15,9 @@ LOG = logging.getLogger(__name__)
 def init(context, reset, force):
     """Setup the database."""
     store: Store = context.obj["store"]
-    existing_tables = store.engine.table_names()
+    inspector = inspect(store.engine)
+    existing_tables = inspector.get_table_names()
+
     if force or reset:
         if existing_tables and not force:
             message = f"Delete existing tables? [{', '.join(existing_tables)}]"
@@ -24,4 +28,4 @@ def init(context, reset, force):
         context.abort()
 
     store.create_all()
-    LOG.info("Success! New tables: %s", ", ".join(store.engine.table_names()))
+    LOG.info("Success! New tables: %s", ", ".join(inspector.get_table_names()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Click<7
 coloredlogs
 marshmallow
 pyyaml
-SQLAlchemy==1.4
+SQLAlchemy<=1.4
 rich

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Click<7
 coloredlogs
 marshmallow
 pyyaml
-SQLAlchemy<1.4
+SQLAlchemy==1.4
 rich


### PR DESCRIPTION
## Description
This PR migrates housekeeper to SQLAlchemy 1.4. Part of https://github.com/Clinical-Genomics/cg/issues/2497.

### Fixed
- Migrate SQLAlchemy to 1.4

Blocked by upgrading cg to SQLAlchemy 1.4 as well.

EDIT:
To be able to start migrating cg to 1.4, the requirement for sqlalchemy is set to <=1.4 and this PR needs to be merged.

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
