### PR TITLE
Allow for latest 1.4 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Click<7
 coloredlogs
 marshmallow
 pyyaml
-SQLAlchemy<=1.4
+SQLAlchemy>=1.3.0,<1.5.0
 rich


### PR DESCRIPTION
## Description
I want to use the latest 1.4.x version when upgrading in cg, and the way it was locked here only allows for 1.4.0.
The version used in housekeeper and cg will remain on the 1.3 series until the initial migration in cg is completed.

### Fixed
- sqlalchemy version lock

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
