### PR TITLE
Upgrade to click 8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Click<7
+Click
 coloredlogs
 marshmallow
 pyyaml


### PR DESCRIPTION
## Description
According to the [Click migration docs](https://click.palletsprojects.com/en/8.1.x/upgrading/#), no breaking changes need to be addressed in housekeeper. The the only breaking change since version 6 seems to be that commands that take their name from the decorated function now replace underscores with dashes. We don't have any such commands, all commands are explicitly given a separate name.

### Fixed
- Upgrade click from version 6 to 8

## Testing
Test that the commands execute as before (not really necessary since we have pytests for this already.)


This PR is blocked by migrating to click 8 in cg as well, which in turn is blocked by upgrading flask.

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
