### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -13,10 +13,10 @@ jobs:
    - name: Check out git repository
      uses: actions/checkout@v2.6.0
 
-   - name: Set up Python 3.8
+   - name: Set up Python 3.10
      uses: actions/setup-python@v2
      with:
-      python-version: 3.8
+      python-version: "3.10"
 
    - name: Install build tools
      run: >-

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version}}
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Housekeeper Dependencies
         run: |

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
 
     steps:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.8-slim
+FROM python:3.10-slim
 
-LABEL base_image="python:3.8-slim"
+LABEL base_image="python:3.10-slim"
 LABEL software="housekeeper"
 LABEL about.summary="Image for housekeeper"
 LABEL about.home="https://github.com/Clinical-Genomics/housekeeper"


### PR DESCRIPTION
## Description
This PR upgrades housekeeper to use Python 3.10. The code base is not affected by any of the [breaking changes](https://docs.python.org/3/whatsnew/3.10.html#porting-to-python-3-10).

Blocked by https://github.com/Clinical-Genomics/cg/pull/2566.

### Fixed
- Upgrade to Python 3.10

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
