### PR TITLE
Replace deprecated import

### DIFF
--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -4,7 +4,7 @@ import datetime as dt
 from pathlib import Path
 
 from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint, orm, types
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import backref
 
 Model = declarative_base()


### PR DESCRIPTION
## Description
Fixes
```
housekeeper/store/models.py:10
MovedIn20Warning: 
The ``declarative_base()`` function is now available as sqlalchemy.orm.declarative_base(). 
(deprecated since: 1.4) 
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
```

### Fixed
- Deprecated sqlalchemy import


This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
