### PR TITLE
Remove models as properties

### DIFF
--- a/housekeeper/store/api/core.py
+++ b/housekeeper/store/api/core.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 
 from housekeeper.store.api.handlers.update import UpdateHandler
-from housekeeper.store.models import Model
+from housekeeper.store.models import File, Model, Version
 from housekeeper.store.api.handlers.create import CreateHandler
 from housekeeper.store.api.handlers.read import ReadHandler
 
@@ -40,8 +40,8 @@ class Store(CoreHandler):
         self.session = scoped_session(session_factory)
 
         LOG.debug("Initializing Store")
-        self.File.app_root = Path(root)
-        self.Version.app_root = Path(root)
+        File.app_root = Path(root)
+        Version.app_root = Path(root)
 
         super().__init__(self.session)
 

--- a/housekeeper/store/api/handlers/base.py
+++ b/housekeeper/store/api/handlers/base.py
@@ -8,12 +8,6 @@ from sqlalchemy.orm import Query, Session
 class BaseHandler:
     """This is a base class holding different models."""
 
-    Archive: Type[Model] = Archive
-    Bundle: Type[Model] = Bundle
-    Version: Type[Model] = Version
-    File: Type[Model] = File
-    Tag: Type[Model] = Tag
-
     def __init__(self, session: Session):
         self.session = session
 

--- a/housekeeper/store/api/handlers/create.py
+++ b/housekeeper/store/api/handlers/create.py
@@ -26,7 +26,7 @@ class CreateHandler(BaseHandler):
 
     def new_bundle(self, name: str, created_at: dt.datetime = None) -> Bundle:
         """Create a new file bundle."""
-        new_bundle = self.Bundle(name=name, created_at=created_at)
+        new_bundle = Bundle(name=name, created_at=created_at)
         LOG.debug("Created new bundle: %s", new_bundle.name)
         return new_bundle
 
@@ -77,7 +77,7 @@ class CreateHandler(BaseHandler):
     def new_version(self, created_at: dt.datetime, expires_at: dt.datetime = None) -> Version:
         """Create a new bundle version."""
         LOG.debug("Created new version")
-        new_version = self.Version(created_at=created_at, expires_at=expires_at)
+        new_version = Version(created_at=created_at, expires_at=expires_at)
         return new_version
 
     def add_version(
@@ -146,11 +146,11 @@ class CreateHandler(BaseHandler):
         tags: List[Tag] = None,
     ) -> File:
         """Create a new file object based on the information given."""
-        return self.File(path=path, checksum=checksum, to_archive=to_archive, tags=tags)
+        return File(path=path, checksum=checksum, to_archive=to_archive, tags=tags)
 
     def new_tag(self, name: str, category: str = None) -> Tag:
         """Create a new tag object based on the information given."""
-        new_tag = self.Tag(name=name, category=category)
+        new_tag = Tag(name=name, category=category)
         return new_tag
 
     def create_archive(self, file_id: int, archiving_task_id: int) -> Archive:

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -114,7 +114,7 @@ class ReadHandler(BaseHandler):
         if bundle_name:
             LOG.debug(f"Fetching files from bundle {bundle_name}")
             query = apply_bundle_filter(
-                bundles=query.join(self.File.version, self.Version.bundle),
+                bundles=query.join(File.version, Version.bundle),
                 filter_functions=[BundleFilters.FILTER_BY_NAME],
                 bundle_name=bundle_name,
             )
@@ -132,7 +132,7 @@ class ReadHandler(BaseHandler):
         if version_id:
             LOG.debug(f"Fetching files from version {version_id}")
             query = apply_version_filter(
-                versions=query.join(self.File.version),
+                versions=query.join(File.version),
                 filter_functions=[VersionFilter.FILTER_BY_ID],
                 version_id=version_id,
             )


### PR DESCRIPTION
## Description
This PR removes the models from the handler classes (like we have done in cg). There is no purpose of having them there.

### Fixed
- Remove models as attributes from handlers

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
