### PR TITLE
Fix version file warnings

### DIFF
--- a/housekeeper/store/api/handlers/create.py
+++ b/housekeeper/store/api/handlers/create.py
@@ -73,6 +73,7 @@ class CreateHandler(BaseHandler):
                 tags = [tag_map[tag_name] for tag_name in file_data["tags"]]
                 new_file = self.new_file(path, to_archive=file_data["archive"], tags=tags)
                 version_obj.files.append(new_file)
+                new_file.version_id = version_obj.id
 
     def new_version(self, created_at: dt.datetime, expires_at: dt.datetime = None) -> Version:
         """Create a new bundle version."""

--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -63,7 +63,9 @@ class Version(Model):
     archive_checksum = Column(types.String(256), unique=True)
 
     bundle_id = Column(ForeignKey(Bundle.id, ondelete="CASCADE"), nullable=False)
-    files = orm.relationship("File", backref="version", cascade="delete, save-update")
+    files = orm.relationship(
+        "File", backref=backref("version", cascade_backrefs=False), cascade="delete, save-update"
+    )
 
     app_root = None
 


### PR DESCRIPTION
RemovedIn20Warning: "Version" object is being merged into a Session along the backref cascade path for relationship "Bundle.versions"; in SQLAlchemy 2.0, this reverse cascade will not take place.  Set cascade_backrefs to False in either the relationship() or backref() function for the 2.0 behavior; or to set globally for the whole Session, set the future=True flag (Background on this error at: https://sqlalche.me/e/14/s9r1) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    version_obj.bundle = bundle

## Description

### Added

-

### Changed

-

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_main -t housekeeper -b YOURBRANCH```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
