### PR TITLE
Fix session merge warnings

### DIFF
--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -65,7 +65,7 @@ class Version(Model):
 
     bundle_id = Column(ForeignKey(Bundle.id, ondelete="CASCADE"), nullable=False)
     files = orm.relationship(
-        "File", backref=backref("version", cascade_backrefs=False), cascade="delete, save-update"
+        "File", backref="version", cascade="delete, save-update", cascade_backrefs=False
     )
 
     app_root = None
@@ -92,7 +92,9 @@ class File(Model):
     to_archive = Column(types.Boolean, nullable=False, default=False)
 
     version_id = Column(ForeignKey(Version.id, ondelete="CASCADE"), nullable=False)
-    tags = orm.relationship("Tag", secondary=file_tag_link, backref="files")
+    tags = orm.relationship(
+        "Tag", secondary=file_tag_link, backref=backref("files", cascade_backrefs=False)
+    )
 
     app_root = None
 

--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -63,7 +63,9 @@ class Version(Model):
     archive_checksum = Column(types.String(256), unique=True)
 
     bundle_id = Column(ForeignKey(Bundle.id, ondelete="CASCADE"), nullable=False)
-    files = orm.relationship("File", backref="version", cascade="delete, save-update")
+    files = orm.relationship(
+        "File", backref=backref("version", cascade_backrefs=False), cascade="delete, save-update"
+    )
 
     app_root = None
 

--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -44,6 +44,7 @@ class Bundle(Model):
         backref="bundle",
         order_by="-Version.created_at",
         cascade="delete, save-update",
+        cascade_backrefs=False,
     )
 
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -38,8 +38,9 @@ class Helpers:
     @staticmethod
     def add_bundle(store: Store, bundle: dict) -> None:
         """Add and commit bundle to housekeeper store"""
-        bundle_obj, _ = store.add_bundle(bundle)
+        bundle_obj, version = store.add_bundle(bundle)
         store.session.add(bundle_obj)
+        store.session.add(version)
         store.session.commit()
 
     @staticmethod
@@ -54,14 +55,7 @@ class Helpers:
 
     @staticmethod
     def create_bundle_data(case_id: str, files: List[dict], created_at: dt.datetime = None) -> dict:
-        """
-        Create a new bundle_data dictionary with the given parameters.
-
-        :param case_id: The name of the bundle.
-        :param files: A list of dictionaries representing file data.
-        :param created_at: The timestamp when the bundle was created (optional).
-        :return: A dictionary representing the bundle data.
-        """
+        """Create a new bundle_data dictionary with the given parameters."""
         if created_at is None:
             created_at = dt.datetime.now()
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -53,7 +53,7 @@ class Helpers:
         return new_archive
 
     @staticmethod
-    def create_bundle_data(case_id: str, files: List[dict], created_at: dt.datetime = None) -> dict:
+    def create_bundle_data(case_id: str, files: list[dict], created_at: dt.datetime = None) -> dict:
         """Create a new bundle_data dictionary with the given parameters."""
 
         if created_at is None:

--- a/tests/store/handlers/test_createhandler.py
+++ b/tests/store/handlers/test_createhandler.py
@@ -118,8 +118,9 @@ def test_add_two_versions_of_bundle(populated_store: Store, second_bundle_data: 
     starting_file_count: int = store._get_query(table=File).count()
 
     # WHEN adding the modified bundle to the database
-    new_bundle_obj = store.add_bundle(second_bundle_data)[0]
+    new_bundle_obj, version = store.add_bundle(second_bundle_data)
     store.session.add(new_bundle_obj)
+    store.session.add(version)
     store.session.commit()
 
     # THEN there should still be the same number of bundles


### PR DESCRIPTION
## Description
This PR fixes some deprecation warnings for SQLAlchemy 1.4, see [change](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#change-5150). Part of https://github.com/Clinical-Genomics/cg/issues/2497.

The breaking change consists of
```python
version = Version()
session.add(version)

file = File()
file.version = version  # <--- adds "file" to the session automatically, won't happen in 2.0
```
Example warning (EDIT: generated by setting `export SQLALCHEMY_WARN_20=1`and running `pytest -W always`):
```
RemovedIn20Warning: 
"File" object is being merged into a Session along the backref cascade path for relationship "Version.files"; 
in SQLAlchemy 2.0, this reverse cascade will not take place.  Set cascade_backrefs to False in
either the relationship() or backref() function for the 2.0 behavior; or to set globally for the whole 
Session, set the future=True flag 
(Background on this error at: https://sqlalche.me/e/14/s9r1)
(Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    new_file.version = version
```

 Each warning was checked and the codebase looked over to see if we relied on the implicit add somewhere. `cascade_backrefs` was then set to False to turn off the automatic add to the session.
 
 The housekeeper module in `cg` needs to be checked before this is merged to ensure that we don't rely on the old behaviour. This PR is fairly high risk and could potentially cause data loss. Please take some time reviewing it.

### Fixed
- Deprecated automatic merging of objects into the session

This [version](https://semver.org/) is a:
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
