### PR TITLE
feat(CLI command for delete tag)

### DIFF
--- a/housekeeper/cli/delete.py
+++ b/housekeeper/cli/delete.py
@@ -41,7 +41,7 @@ def bundle_cmd(context, yes, bundle_name):
 
     store.session.delete(bundle)
     store.session.commit()
-    LOG.info("Bundle deleted: %s", bundle.name)
+    LOG.info(f"Deleted bundle {bundle.name}")
 
 
 @delete.command("version")
@@ -59,18 +59,18 @@ def version_cmd(context, bundle_name, version_id, yes):
     if bundle_name:
         bundle = store.get_bundle_by_name(bundle_name=bundle_name)
         if not bundle:
-            LOG.info("Could not find bundle %s", bundle_name)
+            LOG.info(f"Could not find bundle {bundle_name}")
             return
         if len(bundle.versions) == 0:
-            LOG.warning("Could not find versions for bundle %s", bundle_name)
+            LOG.warning(f"Could not find versions for bundle {bundle_name}")
             return
-        LOG.info("Deleting the latest version of bundle %s", bundle_name)
+        LOG.info(f"Deleting the latest version of bundle {bundle_name}")
         version_obj = bundle.versions[0]
 
     if version_id:
         version = store.get_version_by_id(version_id=version_id)
         if not version:
-            LOG.warning("Could not find version %s", version_id)
+            LOG.warning(f"Could not find version {version_id}")
             raise click.Abort
         bundle = store.get_bundle_by_id(bundle_id=version.bundle_id)
         for ver in bundle.versions:
@@ -78,9 +78,9 @@ def version_cmd(context, bundle_name, version_id, yes):
                 version_obj = ver
 
     if version_obj.included_at:
-        question = f"remove bundle version from file system and database: {version_obj.full_path}"
+        question = f"Remove bundle version {version_obj.full_path} from file system and database?"
     else:
-        question = f"remove bundle version from database: {version_obj.created_at.date()}"
+        question = f"Remove bundle version {version_obj.created_at.date()} from database?"
 
     if not (yes or click.confirm(question)):
         raise click.Abort
@@ -90,7 +90,7 @@ def version_cmd(context, bundle_name, version_id, yes):
 
     store.session.delete(version_obj)
     store.session.commit()
-    LOG.info("version deleted: %s", version_obj.full_path)
+    LOG.info(f"version deleted: {version_obj.full_path}")
 
 
 @delete.command("files")
@@ -131,7 +131,7 @@ def files_cmd(context, yes, tag, bundle_name, before, notondisk, list_files, lis
         raise click.Abort
 
     for file in files:
-        if yes or click.confirm(f"remove file from disk and database: {file.full_path}"):
+        if yes or click.confirm(f"Remove file from disk and database: {file.full_path}?"):
             delete_file(file=file, store=store)
 
 
@@ -149,7 +149,7 @@ def tag_cmd(context, yes, name: str):
         raise click.Abort
 
     tag_file_count: int = len(tag.files) if tag.files else 0
-    question = f"delete tag {name} with {tag_file_count} associated files?"
+    question = f"Delete tag {name} with {tag_file_count} associated files?"
 
     if yes or click.confirm(question):
         store.session.delete(tag)
@@ -223,9 +223,9 @@ def file_cmd(context, yes, file_id):
         raise click.Abort
 
     if file.is_included:
-        question = f"remove file from file system and database: {file.full_path}"
+        question = f"Remove file {file.full_path} from file system and database?"
     else:
-        question = f"remove file from database: {file.full_path}"
+        question = f"Remove file {file.full_path} from database?"
 
     if yes or click.confirm(question):
         if file.is_included and Path(file.full_path).exists():

--- a/housekeeper/cli/delete.py
+++ b/housekeeper/cli/delete.py
@@ -3,6 +3,7 @@
 import logging
 import shutil
 from pathlib import Path
+from typing import Optional
 
 import click
 
@@ -142,13 +143,13 @@ def tag_cmd(context, yes, name: str):
     """Delete a tag from the database.
     Entries in the file_tag_link table associated with the tag will be removed."""
     store: Store = context.obj["store"]
-    tag: Tag = store.get_tag(tag_name=name)
+    tag: Tag | None = store.get_tag(tag_name=name)
     if not tag:
         LOG.warning(f"Tag {name} not found")
         raise click.Abort
 
-    tag_files: int = len(tag.files) if tag.files else 0
-    question = f"delete tag {name} with {tag_files} associated files?"
+    tag_file_count: int = len(tag.files) if tag.files else 0
+    question = f"delete tag {name} with {tag_file_count} associated files?"
 
     if yes or click.confirm(question):
         store.session.delete(tag)

--- a/housekeeper/cli/delete.py
+++ b/housekeeper/cli/delete.py
@@ -153,7 +153,7 @@ def tag_cmd(context, yes, name: str):
     if yes or click.confirm(question):
         store.session.delete(tag)
         store.session.commit()
-        LOG.info("Tag deleted")
+        LOG.info(f"Tag {name} deleted")
 
 
 def validate_delete_options(tag: str, bundle_name: str):

--- a/housekeeper/store/api/handlers/create.py
+++ b/housekeeper/store/api/handlers/create.py
@@ -31,7 +31,7 @@ class CreateHandler(BaseHandler):
         LOG.debug("Created new bundle: %s", new_bundle.name)
         return new_bundle
 
-    def add_bundle(self, data: dict) -> Tuple[Bundle, Version]:
+    def add_bundle(self, data: dict) -> Tuple[Bundle, Version] | None:
         """Build a new bundle version of files.
 
         The format of the input dict is defined in the `schema` module.

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -9,10 +9,7 @@ from typing import Optional, Set
 from sqlalchemy.orm import Query, Session
 
 from housekeeper.store.api.handlers.base import BaseHandler
-from housekeeper.store.filters.archive_filters import (
-    ArchiveFilter,
-    apply_archive_filter,
-)
+from housekeeper.store.filters.archive_filters import ArchiveFilter, apply_archive_filter
 from housekeeper.store.filters.bundle_filters import BundleFilters, apply_bundle_filter
 from housekeeper.store.filters.file_filters import FileFilter, apply_file_filter
 from housekeeper.store.filters.tag_filters import TagFilter, apply_tag_filter
@@ -20,10 +17,7 @@ from housekeeper.store.filters.version_bundle_filters import (
     VersionBundleFilters,
     apply_version_bundle_filter,
 )
-from housekeeper.store.filters.version_filters import (
-    VersionFilter,
-    apply_version_filter,
-)
+from housekeeper.store.filters.version_filters import VersionFilter, apply_version_filter
 from housekeeper.store.models import Archive, Bundle, File, Tag, Version
 
 LOG = logging.getLogger(__name__)
@@ -91,7 +85,7 @@ class ReadHandler(BaseHandler):
         LOG.debug("Fetching all tags")
         return self._get_query(table=Tag)
 
-    def get_file_by_id(self, file_id: int):
+    def get_file_by_id(self, file_id: int) -> File | None:
         """Get a file by record id."""
         return apply_file_filter(
             files=self._get_query(table=File),

--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -4,8 +4,7 @@ import datetime as dt
 from pathlib import Path
 
 from sqlalchemy import Column, ForeignKey, Table, UniqueConstraint, orm, types
-from sqlalchemy.orm import declarative_base
-from sqlalchemy.orm import backref
+from sqlalchemy.orm import backref, declarative_base
 
 Model = declarative_base()
 

--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -12,8 +12,8 @@ Model = declarative_base()
 file_tag_link = Table(
     "file_tag_link",
     Model.metadata,
-    Column("file_id", types.Integer, ForeignKey("file.id"), nullable=False),
-    Column("tag_id", types.Integer, ForeignKey("tag.id"), nullable=False),
+    Column("file_id", types.Integer, ForeignKey("file.id", ondelete="CASCADE"), nullable=False),
+    Column("tag_id", types.Integer, ForeignKey("tag.id", ondelete="CASCADE"), nullable=False),
     UniqueConstraint("file_id", "tag_id", name="_file_tag_uc"),
 )
 

--- a/tests/cli/delete/test_cli_delete_bundle.py
+++ b/tests/cli/delete/test_cli_delete_bundle.py
@@ -1,5 +1,6 @@
 """Tests for delete CLI functions"""
 import logging
+
 from click import Context
 from click.testing import CliRunner
 
@@ -77,4 +78,4 @@ def test_delete_existing_bundle_no_versions_with_confirmation(
     # THEN assert it exits non zero
     assert result.exit_code == 0
     # THEN it should communicate that it was deleted
-    assert "Bundle deleted" in caplog.text
+    assert f"Deleted bundle {case_id}" in caplog.text

--- a/tests/cli/delete/test_cli_delete_file.py
+++ b/tests/cli/delete/test_cli_delete_file.py
@@ -1,6 +1,7 @@
 """Tests for delete CLI functions"""
 
 import logging
+
 from click import Context
 from click.testing import CliRunner
 
@@ -43,7 +44,7 @@ def test_delete_existing_file_with_confirmation(
     result = cli_runner.invoke(delete.file_cmd, [str(file_id)], obj=populated_context)
 
     # THEN it should ask if you are sure
-    assert "remove file from" in result.output
+    assert "Remove file " in result.output
 
 
 def test_delete_existing_file_no_confirmation(

--- a/tests/cli/delete/test_cli_delete_tag.py
+++ b/tests/cli/delete/test_cli_delete_tag.py
@@ -39,7 +39,7 @@ def test_delete_existing_tag_with_confirmation(
     # WHEN trying to delete the tag
     result = cli_runner.invoke(delete.tag_cmd, ["--name", family_tag_name], obj=populated_context)
 
-    # THEN the confirmation question shoul dbe shown in stdout
+    # THEN the confirmation question should be shown in stdout
     assert f"delete tag {family_tag_name} with" in result.output
 
 
@@ -58,6 +58,7 @@ def test_delete_existing_tag_no_confirmation(
         delete.tag_cmd, ["--name", family_tag_name, "--yes"], obj=populated_context
     )
 
-    # THEN the confirmation question should be shown in stdout
+    # THEN the tag should have been deleted
     assert result.exit_code == 0
     assert f"Tag {family_tag_name} deleted" in caplog.text
+    assert not store.get_tag(tag_name=family_tag_name)

--- a/tests/cli/delete/test_cli_delete_tag.py
+++ b/tests/cli/delete/test_cli_delete_tag.py
@@ -1,0 +1,35 @@
+"""Tests for delete CLI functions"""
+import logging
+
+from click import Context
+from click.testing import CliRunner
+
+from housekeeper.cli import delete
+from housekeeper.store.api.core import Store
+
+
+def test_delete_non_existing_tag(
+    non_existent_tag_name: str,
+    base_context: Context,
+    cli_runner: CliRunner,
+    caplog,
+):
+    """."""
+    # GIVEN a tag that does not exist
+
+    # WHEN trying to delete the non-existent tag
+    result = cli_runner.invoke(delete.tag_cmd, ["--name", non_existent_tag_name], obj=base_context)
+
+    # THEN assert it exits non zero
+    assert result.exit_code == 1
+    # THEN it should communicate that the tag was not found
+    assert f"Tag {non_existent_tag_name} not found" in caplog.text
+
+
+def test_delete_tag():
+    """."""
+    # GIVEN
+
+    # WHEN
+
+    # THEN

--- a/tests/cli/delete/test_cli_delete_tag.py
+++ b/tests/cli/delete/test_cli_delete_tag.py
@@ -40,7 +40,7 @@ def test_delete_existing_tag_with_confirmation(
     result = cli_runner.invoke(delete.tag_cmd, ["--name", family_tag_name], obj=populated_context)
 
     # THEN the confirmation question should be shown in stdout
-    assert f"delete tag {family_tag_name} with" in result.output
+    assert f"Delete tag {family_tag_name} with" in result.output
 
 
 def test_delete_existing_tag_no_confirmation(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,7 @@ import yaml
 from housekeeper.date import get_date
 from housekeeper.store import Store
 from housekeeper.store.models import Archive, Bundle, Tag, Version
-
-from .helper_functions import Helpers
+from tests.helper_functions import Helpers
 
 # basic fixtures
 


### PR DESCRIPTION
## Description
Closes #101. Adds a new CLI command `housekeeper delete tag --name <tag-name>`

### Added

- CLI function `tag_cmd` in `housekeeper.cli.delete`
- Tests

### Changed

- The `file_tag_link` table, adding the `ondelete="CASCADE"` option to the ForeignKey so that when a tag is deleted, all entries with the tag in the table are deleted too. The same for deleting files. 

### Fixed

- Spelling and formatted strings

## Testing

### How to prepare for test

- [x] ssh to hasta (depending on type of change)
- [x] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t housekeeper -b delete-tag```

### How to test
- [x] See that the command exists `housekeeper delete tag --help`
- [x] Try to delete a non-existing tag `housekeeper delete tag --name non-existent`
- [x] Delete a tag with confirmation
- [x] Delete a tag without confirmation

### Expected test outcome
- [x] check that the help for the command is printed correctly
- [x] Check that the proper error message is printed when the tag does not exist
- [x] verify that the tag was deleted when the tag was removed

## Review
- [x] code approved by SA, IO
- [x] tests executed by SD
- [x] "Merge and deploy" approved by SA, IO
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [x] **MINOR** - when you add functionality in a backwards compatible manner
