### PR TITLE
(Archive) Get archive entries by archival/retrieval id

### DIFF
--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -9,10 +9,7 @@ from typing import Optional, Set
 from sqlalchemy.orm import Query, Session
 
 from housekeeper.store.api.handlers.base import BaseHandler
-from housekeeper.store.filters.archive_filters import (
-    ArchiveFilter,
-    apply_archive_filter,
-)
+from housekeeper.store.filters.archive_filters import ArchiveFilter, apply_archive_filter
 from housekeeper.store.filters.bundle_filters import BundleFilters, apply_bundle_filter
 from housekeeper.store.filters.file_filters import FileFilter, apply_file_filter
 from housekeeper.store.filters.tag_filters import TagFilter, apply_tag_filter
@@ -20,10 +17,7 @@ from housekeeper.store.filters.version_bundle_filters import (
     VersionBundleFilters,
     apply_version_bundle_filter,
 )
-from housekeeper.store.filters.version_filters import (
-    VersionFilter,
-    apply_version_filter,
-)
+from housekeeper.store.filters.version_filters import VersionFilter, apply_version_filter
 from housekeeper.store.models import Archive, Bundle, File, Tag, Version
 
 LOG = logging.getLogger(__name__)
@@ -249,3 +243,23 @@ class ReadHandler(BaseHandler):
             tag_names=tag_names,
             is_archived=False,
         ).all()
+
+    def get_archives(self, archival_task_id: int, retrieval_task_id: int) -> Optional[list[File]]:
+        """Returns all entries in the archive table with the specified archival/retrieval task id."""
+        if not archival_task_id and not retrieval_task_id:
+            raise ValueError("Please provide a task id for an archival or a retrieval.")
+        if archival_task_id and retrieval_task_id:
+            raise ValueError("Please do not provide both archival_task_id and retrieval_task_id.")
+        if archival_task_id:
+            return apply_archive_filter(
+                archives=self._get_query(table=Archive),
+                filter_functions=[ArchiveFilter.FILTER_BY_ARCHIVING_TASK_ID],
+                task_id=archival_task_id,
+            ).all()
+
+        else:
+            return apply_archive_filter(
+                archives=self._get_query(table=Archive),
+                filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVAL_TASK_ID],
+                task_id=retrieval_task_id,
+            ).all()

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -244,12 +244,22 @@ class ReadHandler(BaseHandler):
             is_archived=False,
         ).all()
 
-    def get_archives(self, archival_task_id: int, retrieval_task_id: int) -> Optional[list[File]]:
+    def get_archives(
+        self, archival_task_id: int = None, retrieval_task_id: int = None
+    ) -> Optional[list[File]]:
         """Returns all entries in the archive table with the specified archival/retrieval task id."""
         if not archival_task_id and not retrieval_task_id:
-            raise ValueError("Please provide a task id for an archival or a retrieval.")
+            return self._get_query(table=Archive).all()
         if archival_task_id and retrieval_task_id:
-            raise ValueError("Please do not provide both archival_task_id and retrieval_task_id.")
+            return apply_archive_filter(
+                archives=apply_archive_filter(
+                    archives=self._get_query(table=Archive),
+                    filter_functions=[ArchiveFilter.FILTER_BY_ARCHIVING_TASK_ID],
+                    task_id=archival_task_id,
+                ),
+                filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVAL_TASK_ID],
+                task_id=retrieval_task_id,
+            ).all()
         if archival_task_id:
             return apply_archive_filter(
                 archives=self._get_query(table=Archive),

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -267,9 +267,8 @@ class ReadHandler(BaseHandler):
                 task_id=archival_task_id,
             ).all()
 
-        else:
-            return apply_archive_filter(
-                archives=self._get_query(table=Archive),
-                filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVAL_TASK_ID],
-                task_id=retrieval_task_id,
-            ).all()
+        return apply_archive_filter(
+            archives=self._get_query(table=Archive),
+            filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVAL_TASK_ID],
+            task_id=retrieval_task_id,
+        ).all()

--- a/housekeeper/store/filters/archive_filters.py
+++ b/housekeeper/store/filters/archive_filters.py
@@ -41,7 +41,7 @@ class ArchiveFilter(Enum):
 
 
 def apply_archive_filter(
-    archives: Query, filter_functions: list[Callable], task_id: int = None
+    archives: Query, filter_functions: list[ArchiveFilter], task_id: int = None
 ) -> Query:
     """Apply filtering functions to archives and return filtered Query."""
     for filter_function in filter_functions:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,13 +60,13 @@ def sample_tag_names(vcf_tag_name: str, sample_tag_name: str) -> list[str]:
     return [vcf_tag_name, sample_tag_name]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def spring_tag() -> str:
     """Return the tag marking SPRING files."""
     return "spring"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def sample_id() -> str:
     """Return name of a sample."""
     return "ACC123456A1"
@@ -132,7 +132,7 @@ def spring_file_2_with_tags(sample_id: str, spring_tag: str, spring_file_2: Path
     return {"tags": [sample_id, spring_tag], "file": spring_file_2}
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def spring_file_3_with_tags(sample_id: str, spring_tag: str, spring_file_3: Path) -> dict:
     """Return a third SPRING file and tags for a sample."""
     return {"tags": [sample_id, spring_tag], "file": spring_file_3}
@@ -341,7 +341,7 @@ def archive(populated_store: Store) -> Archive:
 # dir fixtures
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def fixtures_dir() -> Path:
     """Return the path to the fixtures directory."""
     return Path("tests/fixtures/")
@@ -353,7 +353,7 @@ def vcf_dir(fixtures_dir: Path) -> Path:
     return fixtures_dir / "vcfs"
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def sequencing_files_dir(fixtures_dir: Path) -> Path:
     """Return the path to the sequencing_files fixtures directory."""
     return Path(fixtures_dir, "sequencing_files")
@@ -421,7 +421,7 @@ def spring_file_2(sequencing_files_dir: Path) -> Path:
     return Path(sequencing_files_dir, "lane2.spring")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def spring_file_3(sequencing_files_dir: Path) -> Path:
     """Return the path to a SPRING file."""
     return Path(sequencing_files_dir, "lane3.spring")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,13 +78,7 @@ def archiving_task_id() -> int:
     return 1234
 
 
-@pytest.fixture(scope="function")
-def second_archiving_task_id() -> int:
-    """Return another id of an archiving task."""
-    return 1235
-
-
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def new_archiving_task_id() -> int:
     """Return a new id of an archiving task."""
     return 1235
@@ -502,7 +496,7 @@ def store(project_dir: Path) -> Store:
 @pytest.fixture(scope="function")
 def populated_store(
     archiving_task_id: int,
-    second_archiving_task_id,
+    new_archiving_task_id,
     retrieval_task_id: int,
     bundle_data: dict,
     helpers: Helpers,
@@ -522,7 +516,7 @@ def populated_store(
     retrieval_archive: Archive = helpers.add_archive(
         store=store,
         file_id=store.get_files(file_path=spring_file_3.as_posix()).first().id,
-        archiving_task_id=second_archiving_task_id,
+        archiving_task_id=new_archiving_task_id,
     )
     retrieval_archive.retrieval_task_id = retrieval_task_id
     store.session.commit()

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -198,3 +198,79 @@ def test_get_ongoing_retrieval_tasks(
 
     # THEN the set should include the initial retrieval task id
     assert retrieval_task_id in ongoing_task_ids
+
+
+def test_get_archive_entries_by_archiving_id(
+    archive: Archive, archiving_task_id: int, populated_store: Store
+):
+    """Tests that get_archives returns archive entries with the given archiving task id."""
+
+    # GIVEN a populated store with an archive entry
+
+    # WHEN getting entries with the matching archiving task id
+    archives: list[Archive] = populated_store.get_archives(archival_task_id=archiving_task_id)
+
+    # THEN the matching entry should have been returned
+    assert archive in archives
+
+
+def test_get_archive_entries_by_retrieval_id(retrieval_task_id: int, populated_store: Store):
+    """Tests that get_archives returns archive entries with the given archiving task id."""
+
+    # GIVEN a populated store with an archive entry
+
+    # WHEN getting entries with the matching retrieval task id
+    archives: list[Archive] = populated_store.get_archives(retrieval_task_id=retrieval_task_id)
+
+    # THEN an Archive entry should be returned
+    assert len(archives) > 0
+
+    # THEN all returned entries should have the specified retrieval task id
+    for archive in archives:
+        assert archive.retrieval_task_id == retrieval_task_id
+
+
+def test_archives_not_returned_via_archiving_id(archiving_task_id: int, populated_store: Store):
+    """Tests that only archives with matching archiving task ids are returned."""
+
+    # GIVEN a store with multiple archive entries, out of which only one has the provided archiving task id
+
+    # WHEN fetching all archives
+    all_archives: list[Archive] = populated_store.get_archives()
+
+    # WHEN fetching all archives with a specified archiving task id
+    archiving_archives: list[Archive] = populated_store.get_archives(
+        archival_task_id=archiving_task_id
+    )
+
+    # THEN only archives with the matching retrieval task id is returned
+
+    assert len(all_archives) > len(archiving_archives)
+    for archive in all_archives:
+        if archive.archiving_task_id == archiving_task_id:
+            assert archive in archiving_archives
+        else:
+            assert archive not in archiving_archives
+
+
+def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populated_store: Store):
+    """Tests that only archives with matching retrieval task ids are returned."""
+
+    # GIVEN a store with multiple archive entries, out of which only one has the provided retrieval task id
+
+    # WHEN fetching all archives
+    all_archives: list[Archive] = populated_store.get_archives()
+
+    # WHEN fetching all archives with a specified retrieval task id
+    retrieval_archives: list[Archive] = populated_store.get_archives(
+        retrieval_task_id=retrieval_task_id
+    )
+
+    # THEN only archives with the matching retrieval task id is returned
+
+    assert len(all_archives) > len(retrieval_archives)
+    for archive in all_archives:
+        if archive.retrieval_task_id == retrieval_task_id:
+            assert archive in retrieval_archives
+        else:
+            assert archive not in retrieval_archives

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -223,7 +223,7 @@ def test_get_archive_entries_by_retrieval_id(retrieval_task_id: int, populated_s
     archives: list[Archive] = populated_store.get_archives(retrieval_task_id=retrieval_task_id)
 
     # THEN an Archive entry should be returned
-    assert len(archives) > 0
+    assert archives
 
     # THEN all returned entries should have the specified retrieval task id
     for archive in archives:
@@ -239,18 +239,17 @@ def test_archives_not_returned_via_archiving_id(archiving_task_id: int, populate
     all_archives: list[Archive] = populated_store.get_archives()
 
     # WHEN fetching all archives with a specified archiving task id
-    archiving_archives: list[Archive] = populated_store.get_archives(
+    selected_archives: list[Archive] | None = populated_store.get_archives(
         archival_task_id=archiving_task_id
     )
 
     # THEN only archives with the matching retrieval task id is returned
-
-    assert len(all_archives) > len(archiving_archives)
+    assert len(all_archives) > len(selected_archives)
     for archive in all_archives:
         if archive.archiving_task_id == archiving_task_id:
-            assert archive in archiving_archives
+            assert archive in selected_archives
         else:
-            assert archive not in archiving_archives
+            assert archive not in selected_archives
 
 
 def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populated_store: Store):
@@ -262,15 +261,14 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
     all_archives: list[Archive] = populated_store.get_archives()
 
     # WHEN fetching all archives with a specified retrieval task id
-    retrieval_archives: list[Archive] = populated_store.get_archives(
+    selected_archives: list[Archive] | None = populated_store.get_archives(
         retrieval_task_id=retrieval_task_id
     )
 
     # THEN only archives with the matching retrieval task id is returned
-
-    assert len(all_archives) > len(retrieval_archives)
+    assert len(all_archives) > len(selected_archives)
     for archive in all_archives:
         if archive.retrieval_task_id == retrieval_task_id:
-            assert archive in retrieval_archives
+            assert archive in selected_archives
         else:
-            assert archive not in retrieval_archives
+            assert archive not in selected_archives


### PR DESCRIPTION
## Description

This PR adds functionality for fetching entries from the Archive table providing either an archiving_job_id or a retrieval_task_id.

### Added

- Method get_archives.

## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t housekeeper -b get-archive-entries```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
