### PR TITLE
Return full archive model

### DIFF
--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -206,27 +206,21 @@ class ReadHandler(BaseHandler):
             tag_names=tags,
         ).all()
 
-    def get_ongoing_archiving_tasks(self) -> Set[int]:
+    def get_ongoing_archivals(self) -> list[Archive]:
         """Returns all archiving tasks in the archive table, for entries where the archiving
         field is empty."""
-        return {
-            archive.archiving_task_id
-            for archive in apply_archive_filter(
-                archives=self._get_query(table=Archive),
-                filter_functions=[ArchiveFilter.FILTER_ARCHIVING_ONGOING],
-            ).all()
-        }
+        return apply_archive_filter(
+            archives=self._get_query(table=Archive),
+            filter_functions=[ArchiveFilter.FILTER_ARCHIVING_ONGOING],
+        ).all()
 
-    def get_ongoing_retrieval_tasks(self) -> Set[int]:
+    def get_ongoing_retrievals(self) -> list[Archive]:
         """Returns all retrieval tasks in the archive table, for entries where the retrieved_at
         field is empty."""
-        return {
-            archive.retrieval_task_id
-            for archive in apply_archive_filter(
-                archives=self._get_query(table=Archive),
-                filter_functions=[ArchiveFilter.FILTER_RETRIEVAL_ONGOING],
-            ).all()
-        }
+        return apply_archive_filter(
+            archives=self._get_query(table=Archive),
+            filter_functions=[ArchiveFilter.FILTER_RETRIEVAL_ONGOING],
+        ).all()
 
     def get_bundle_name_from_file_path(self, file_path: str) -> str:
         """Return the bundle name for the specified file."""

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -179,7 +179,9 @@ def test_get_ongoing_archiving_tasks(
     archive.archived_at = None
 
     # WHEN getting ongoing archiving tasks
-    ongoing_task_ids: set[int] = populated_store.get_ongoing_archiving_tasks()
+    ongoing_task_ids: set[int] = set(
+        archive_entry.archiving_task_id for archive_entry in populated_store.get_ongoing_archivals()
+    )
 
     # THEN the set should include the initial archiving task id
     assert archiving_task_id in ongoing_task_ids
@@ -194,7 +196,10 @@ def test_get_ongoing_retrieval_tasks(
     archive.retrieved_at = None
 
     # WHEN getting ongoing retrieval tasks
-    ongoing_task_ids: set[int] = populated_store.get_ongoing_retrieval_tasks()
+    ongoing_task_ids: set[int] = set(
+        archive_entry.retrieval_task_id
+        for archive_entry in populated_store.get_ongoing_retrievals()
+    )
 
     # THEN the set should include the initial retrieval task id
     assert retrieval_task_id in ongoing_task_ids


### PR DESCRIPTION
## Description

When querying ongoing tasks, we need the whole object to be able to track down e.g. where the customer stores data. This PR changes the get_ongoing_archives functionality.

### Fixed

- Return full Archive models in get_ongoing_archivals and get_ongoing_retrievals

## Testing

### How to prepare for test

- [ ] ssh to hasta (depending on type of change)
- [ ] install on stage:
```bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_cg -t housekeeper -b archiving-return-archives```

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
