### PR TITLE
Use future flag on engine

### DIFF
--- a/housekeeper/store/database.py
+++ b/housekeeper/store/database.py
@@ -16,7 +16,7 @@ ENGINE: Optional[Engine] = None
 def initialize_database(db_uri: str) -> None:
     """Initialize the global SQLAlchemy engine and session for housekeeper db."""
     global SESSION, ENGINE
-    ENGINE = create_engine(db_uri, pool_pre_ping=True)
+    ENGINE = create_engine(db_uri, pool_pre_ping=True, future=True)
     session_factory = sessionmaker(ENGINE)
     SESSION = scoped_session(session_factory)
 


### PR DESCRIPTION
## Description
This PR sets the `future=True` flag on the SQLAlchemy engine, the [fourth migration step](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine). Part of https://github.com/Clinical-Genomics/cg/issues/2497.

Setting the future flag means a new engine api becomes available and some 1.x features are dropped. Since no `RemovedIn20Warnings` are generated, this can be done without any additional changes.

### Fixed
- Toggle the SQLAlchemy engine to 2.0

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
