### PR TITLE
Set future flag on session

### DIFF
--- a/housekeeper/store/database.py
+++ b/housekeeper/store/database.py
@@ -17,7 +17,7 @@ def initialize_database(db_uri: str) -> None:
     """Initialize the global SQLAlchemy engine and session for housekeeper db."""
     global SESSION, ENGINE
     ENGINE = create_engine(db_uri, pool_pre_ping=True, future=True)
-    session_factory = sessionmaker(ENGINE)
+    session_factory = sessionmaker(ENGINE, future=True)
     SESSION = scoped_session(session_factory)
 
 


### PR DESCRIPTION
## Description
This PR sets the `future=True` flag on the SQLAlchemy session, the [fifth migration step](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-five-use-the-future-flag-on-session). Part of https://github.com/Clinical-Genomics/cg/issues/2497.

No `RemovedIn20Warnings` are generated, so this can be done without any additional changes.

### Fixed
- Toggle the SQLAlchemy session to 2.0

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

