### PR TITLE
Upgrade SQLAlchemy to 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Click
 coloredlogs
 marshmallow
 pyyaml
-SQLAlchemy>=1.3.0,<1.5.0
+SQLAlchemy>=2.0
 rich


### PR DESCRIPTION
## Description
All the steps have been taken according to the migration guide to be able to switch to SQLAlchemy 2.0. Part of project https://github.com/Clinical-Genomics/cg/issues/2497.

### Fixed
- Upgrade SQLAlchemy to 2.0

### This [version](https://semver.org/) is a
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
