### PR TITLE
(Archiving) Add support for limited fetching

### DIFF
--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -105,7 +105,9 @@ def test_get_archived_files(
     # WHEN asking for all archived files
     archived_files: list[Path] = [
         Path(file.path)
-        for file in populated_store.get_archived_files(bundle_name=sample_id, tags=[spring_tag])
+        for file in populated_store.get_archived_files_for_bundle(
+            bundle_name=sample_id, tags=[spring_tag]
+        )
     ]
 
     # THEN only one should be returned
@@ -126,7 +128,9 @@ def test_get_non_archived_files(
     # WHEN asking for all non-archived files
     archived_files: list[Path] = [
         Path(file.path)
-        for file in populated_store.get_non_archived_files(bundle_name=sample_id, tags=[spring_tag])
+        for file in populated_store.get_non_archived_files_for_bundle(
+            bundle_name=sample_id, tags=[spring_tag]
+        )
     ]
 
     # THEN only one should be returned
@@ -155,7 +159,7 @@ def test_get_all_non_archived_files(populated_store: Store, spring_tag: str):
     assert all_files
 
     # WHEN retrieving all non archived spring files
-    non_archived_spring_files: list[File] = populated_store.get_all_non_archived_files([spring_tag])
+    non_archived_spring_files: list[File] = populated_store.get_non_archived_files([spring_tag])
 
     # THEN entries should be returned
     assert non_archived_spring_files

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -94,7 +94,7 @@ def test_get_no_get_files_before_oldest(populated_store, bundle_data_old, old_ti
     assert len(files) == 0
 
 
-def test_get_archived_files_in_bundle(
+def test_get_archived_files_for_bundle(
     archived_file: Path,
     non_archived_file: Path,
     populated_store: Store,
@@ -117,7 +117,7 @@ def test_get_archived_files_in_bundle(
     assert non_archived_file not in archived_files
 
 
-def test_get_non_archived_files_in_bundle(
+def test_get_non_archived_files_for_bundle(
     archived_file: Path,
     non_archived_file: Path,
     populated_store: Store,

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -2,6 +2,8 @@
 from datetime import timedelta
 from pathlib import Path
 
+import pytest
+
 from housekeeper.store import Store
 from housekeeper.store.models import Archive, File, Tag
 
@@ -92,7 +94,7 @@ def test_get_no_get_files_before_oldest(populated_store, bundle_data_old, old_ti
     assert len(files) == 0
 
 
-def test_get_archived_files(
+def test_get_archived_files_in_bundle(
     archived_file: Path,
     non_archived_file: Path,
     populated_store: Store,
@@ -115,7 +117,7 @@ def test_get_archived_files(
     assert non_archived_file not in archived_files
 
 
-def test_get_non_archived_files(
+def test_get_non_archived_files_in_bundle(
     archived_file: Path,
     non_archived_file: Path,
     populated_store: Store,
@@ -151,7 +153,8 @@ def test_get_bundle_name_from_file_path(
     assert bundle_name == sample_id
 
 
-def test_get_all_non_archived_files(populated_store: Store, spring_tag: str):
+@pytest.mark.parametrize("limit", [None, 0])
+def test_get_non_archived_files(populated_store: Store, spring_tag: str, limit: int | None):
     """Test that getting all non-archived spring files from the store
     returns all files fulfilling said condition."""
     # GIVEN a populated store containing SPRING and non-SPRING entries
@@ -159,19 +162,28 @@ def test_get_all_non_archived_files(populated_store: Store, spring_tag: str):
     assert all_files
 
     # WHEN retrieving all non archived spring files
-    non_archived_spring_files: list[File] = populated_store.get_non_archived_files([spring_tag])
+    non_archived_spring_files: list[File] = populated_store.get_non_archived_files(
+        tag_names=[spring_tag], limit=limit
+    )
 
-    # THEN entries should be returned
-    assert non_archived_spring_files
+    # WHEN no limit was set
+    if limit is None:
+        # THEN entries should be returned
+        assert non_archived_spring_files
 
-    # THEN all files with archives and the SPRING tag should be returned
-    for file in all_files:
-        if file not in non_archived_spring_files:
-            assert file.archive or spring_tag not in [tag.name for tag in file.tags]
-        else:
-            assert not file.archive
-            assert spring_tag in [tag.name for tag in file.tags]
-            assert file in non_archived_spring_files
+        # THEN all files with archives and the SPRING tag should be returned
+        for file in all_files:
+            if file not in non_archived_spring_files:
+                assert file.archive or spring_tag not in [tag.name for tag in file.tags]
+            else:
+                assert not file.archive
+                assert spring_tag in [tag.name for tag in file.tags]
+                assert file in non_archived_spring_files
+
+    # WHEN a limit is set to not fetch any files
+    else:
+        # THEN no files should be returned
+        assert not non_archived_spring_files
 
 
 def test_get_ongoing_archiving_tasks(


### PR DESCRIPTION
## Description

This PR adds support for fetching only a limited amount of non-archived spring files.

### Changed

- Renamed get_archived_files and get_non_archived_files to get_archived_files_for_bundle and get_non_archived_files_for_bundle respectively.
- Renamed get_all_non_archived_files to get_non_archived_files and added the option to limit the number of files returned.

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy archiving-fetch-limited-files
housekeeper-test --help
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
