### PR TITLE
(Archiving) Add cascade property to Archive

### DIFF
--- a/housekeeper/store/models.py
+++ b/housekeeper/store/models.py
@@ -27,7 +27,7 @@ class Archive(Model):
     archived_at = Column(types.DateTime(), nullable=True)
     retrieved_at = Column(types.DateTime(), nullable=True)
 
-    file = orm.relationship("File", backref=backref("archive", uselist=False))
+    file = orm.relationship("File", back_populates="archive")
 
 
 class Bundle(Model):
@@ -93,6 +93,9 @@ class File(Model):
     version_id = Column(ForeignKey(Version.id, ondelete="CASCADE"), nullable=False)
     tags = orm.relationship(
         "Tag", secondary=file_tag_link, backref=backref("files", cascade_backrefs=False)
+    )
+    archive = orm.relationship(
+        "Archive", back_populates="file", cascade="save-update, merge, delete", uselist=False
     )
 
     app_root = None

--- a/tests/store/test_models.py
+++ b/tests/store/test_models.py
@@ -47,7 +47,7 @@ def test_delete_file_cascades(archive: Archive, populated_store: Store):
 
     # THEN the archive entry should be deleted
     for archive_entry in populated_store.get_archives(archival_task_id=archive_task_id):
-        assert not archive_entry.file.id == file_id
+        assert archive_entry.file.id != file_id
 
 
 def test_delete_archive_does_not_cascade(archive: Archive, populated_store: Store):


### PR DESCRIPTION
## Description

When deleting a file entry in Housekeeper, any associated entry in the Archive table (i.e. with a matching file_id) should also be deleted. Currently one can not delete a file when there is an archive entry associated to it. This PR adds that cascade property and adds some tests.

### Fixed

- Deleting a file now cascades to the archive table.

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy cascade-archive
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
