### PR TITLE
(Archiving) Abort delete file command when file is archived

### DIFF
--- a/housekeeper/cli/delete.py
+++ b/housekeeper/cli/delete.py
@@ -130,6 +130,11 @@ def files_cmd(context, yes, tag, bundle_name, before, notondisk, list_files, lis
         raise click.Abort
 
     for file in files:
+        if file.archive:
+            LOG.warning(
+                f"File {file.path} is archived, please delete it with 'cg archive delete-file' instead. Skipping."
+            )
+            continue
         if yes or click.confirm(f"Remove file from disk and database: {file.full_path}?"):
             delete_file(file=file, store=store)
 
@@ -219,6 +224,9 @@ def file_cmd(context, yes, file_id):
     file = store.get_file_by_id(file_id=file_id)
     if not file:
         LOG.info("file not found")
+        raise click.Abort
+    if file.archive:
+        LOG.warning("File is archived, please delete it with 'cg archive delete-file' instead")
         raise click.Abort
 
     if file.is_included:

--- a/tests/cli/delete/test_cli_delete_files.py
+++ b/tests/cli/delete/test_cli_delete_files.py
@@ -3,7 +3,6 @@
 import logging
 from pathlib import Path
 
-from click import Context
 from click.testing import CliRunner
 
 from housekeeper.cli import delete
@@ -11,7 +10,7 @@ from housekeeper.store.api.core import Store
 from housekeeper.store.models import Bundle, File
 
 
-def test_delete_files_non_specified(base_context: Context, cli_runner: CliRunner, caplog):
+def test_delete_files_non_specified(base_context: dict, cli_runner: CliRunner, caplog):
     """Test to delete files without specifying bundle name or tag"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a store and a cli runner
@@ -27,7 +26,7 @@ def test_delete_files_non_specified(base_context: Context, cli_runner: CliRunner
 
 
 def test_delete_files_non_existing_bundle(
-    base_context: Context, cli_runner: CliRunner, case_id: str, caplog
+    base_context: dict, cli_runner: CliRunner, case_id: str, caplog
 ):
     """Test to delete a non existing bundle"""
     caplog.set_level(logging.DEBUG)
@@ -45,7 +44,7 @@ def test_delete_files_non_existing_bundle(
 
 
 def test_delete_existing_bundle_with_confirmation(
-    populated_context: Context, cli_runner: CliRunner, case_id: str, caplog
+    populated_context: dict, cli_runner: CliRunner, case_id: str, caplog
 ):
     """Test to delete an existing bundle with confirmation"""
     caplog.set_level(logging.DEBUG)
@@ -66,7 +65,7 @@ def test_delete_existing_bundle_with_confirmation(
 
 
 def test_delete_existing_bundle_no_confirmation(
-    populated_context: Context, cli_runner: CliRunner, case_id: str, caplog
+    populated_context: dict, cli_runner: CliRunner, case_id: str, caplog
 ):
     """Test to delete an existing bundle without confirmation"""
     caplog.set_level(logging.DEBUG)
@@ -93,7 +92,7 @@ def test_delete_existing_bundle_no_confirmation(
 
 
 def test_delete_file_skip_archived(
-    populated_context: Context, cli_runner: CliRunner, spring_file_1: Path, caplog
+    populated_context: dict, cli_runner: CliRunner, spring_file_1: Path, caplog
 ):
     """Tests that an archived file is not deleted via the CLI."""
     caplog.set_level(logging.DEBUG)
@@ -113,9 +112,7 @@ def test_delete_file_skip_archived(
     assert store.get_files(file_path=spring_file_1.as_posix()).first()
 
 
-def test_delete_file(
-    populated_context: Context, cli_runner: CliRunner, spring_file_2: Path, caplog
-):
+def test_delete_file(populated_context: dict, cli_runner: CliRunner, spring_file_2: Path, caplog):
     """Tests that a non-archived file is deleted via the CLI."""
     caplog.set_level(logging.DEBUG)
 

--- a/tests/cli/delete/test_cli_delete_files.py
+++ b/tests/cli/delete/test_cli_delete_files.py
@@ -44,7 +44,7 @@ def test_delete_files_non_existing_bundle(
 
 
 def test_delete_existing_bundle_with_confirmation(
-    populated_context: dict, cli_runner: CliRunner, case_id: str, caplog
+    populated_context: dict, cli_runner: CliRunner, caplog
 ):
     """Test to delete an existing bundle with confirmation"""
     caplog.set_level(logging.DEBUG)
@@ -65,7 +65,7 @@ def test_delete_existing_bundle_with_confirmation(
 
 
 def test_delete_existing_bundle_no_confirmation(
-    populated_context: dict, cli_runner: CliRunner, case_id: str, caplog
+    populated_context: dict, cli_runner: CliRunner, caplog
 ):
     """Test to delete an existing bundle without confirmation"""
     caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
## Description

With the new DataFlow, archived files need to be removed using `cg archive delete-file` since Housekeeper does not communicate with the external API. This PR makes `delete-file` (`delete-files`) in Housekeeper abort (skip) files which are archived and log a warning.

### Changed

- Archived files can no longer be removed via the Housekeeper CLI.

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy archiving-do-not-delete
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
