### PR TITLE
(Archiving) Add retrieved_at filter

### DIFF
--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -272,6 +272,7 @@ class ReadHandler(BaseHandler):
         ).all()
 
     def get_files_retrieved_before(self, date: datetime):
+        """Returns all files which were retrieved before the given date."""
         return apply_archive_filter(
             archives=self._get_join_file_tags_archive_query(),
             filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVED_BEFORE],

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -1,6 +1,7 @@
 """
 This module handles finding things in the store/database
 """
+import datetime
 import datetime as dt
 import logging
 from pathlib import Path
@@ -8,10 +9,7 @@ from pathlib import Path
 from sqlalchemy.orm import Query, Session
 
 from housekeeper.store.api.handlers.base import BaseHandler
-from housekeeper.store.filters.archive_filters import (
-    ArchiveFilter,
-    apply_archive_filter,
-)
+from housekeeper.store.filters.archive_filters import ArchiveFilter, apply_archive_filter
 from housekeeper.store.filters.bundle_filters import BundleFilters, apply_bundle_filter
 from housekeeper.store.filters.file_filters import FileFilter, apply_file_filter
 from housekeeper.store.filters.tag_filters import TagFilter, apply_tag_filter
@@ -19,10 +17,7 @@ from housekeeper.store.filters.version_bundle_filters import (
     VersionBundleFilters,
     apply_version_bundle_filter,
 )
-from housekeeper.store.filters.version_filters import (
-    VersionFilter,
-    apply_version_filter,
-)
+from housekeeper.store.filters.version_filters import VersionFilter, apply_version_filter
 from housekeeper.store.models import Archive, Bundle, File, Tag, Version
 
 LOG = logging.getLogger(__name__)
@@ -249,7 +244,7 @@ class ReadHandler(BaseHandler):
 
     def get_archives(
         self, archival_task_id: int = None, retrieval_task_id: int = None
-    ) -> list[File] | None:
+    ) -> list[Archive] | None:
         """Returns all entries in the archive table with the specified archival/retrieval task id."""
         if not archival_task_id and not retrieval_task_id:
             return self._get_query(table=Archive).all()
@@ -275,3 +270,10 @@ class ReadHandler(BaseHandler):
             filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVAL_TASK_ID],
             task_id=retrieval_task_id,
         ).all()
+
+    def get_files_retrieved_before(self, date: datetime):
+        return apply_archive_filter(
+            archives=self._get_join_file_tags_archive_query(),
+            filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVED_BEFORE],
+            date=date,
+        )

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -271,10 +271,10 @@ class ReadHandler(BaseHandler):
             task_id=retrieval_task_id,
         ).all()
 
-    def get_files_retrieved_before(self, retrieved_before: datetime):
+    def get_files_retrieved_before(self, date: datetime):
         """Returns all files which were retrieved before the given date."""
         return apply_archive_filter(
             archives=self._get_join_file_tags_archive_query(),
             filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVED_BEFORE],
-            retrieved_before=retrieved_before,
+            retrieved_before=date,
         )

--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -271,10 +271,10 @@ class ReadHandler(BaseHandler):
             task_id=retrieval_task_id,
         ).all()
 
-    def get_files_retrieved_before(self, date: datetime):
+    def get_files_retrieved_before(self, retrieved_before: datetime):
         """Returns all files which were retrieved before the given date."""
         return apply_archive_filter(
             archives=self._get_join_file_tags_archive_query(),
             filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVED_BEFORE],
-            date=date,
+            retrieved_before=retrieved_before,
         )

--- a/housekeeper/store/filters/archive_filters.py
+++ b/housekeeper/store/filters/archive_filters.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from enum import Enum
 from typing import Callable
 
@@ -31,6 +32,11 @@ def filter_by_retrieval_task_id(archives: Query, task_id: int, **kwargs) -> Quer
     return archives.filter(Archive.retrieval_task_id == task_id)
 
 
+def filter_by_retrieved_before(archives: Query, date: datetime, **kwargs) -> Query:
+    """Returns archives which were retrieved before the given date."""
+    return archives.filter(Archive.retrieved_at < date)
+
+
 class ArchiveFilter(Enum):
     """Define Archive filter functions."""
 
@@ -38,12 +44,16 @@ class ArchiveFilter(Enum):
     FILTER_RETRIEVAL_ONGOING: Callable = filter_retrieval_ongoing
     FILTER_BY_ARCHIVING_TASK_ID: Callable = filter_by_archiving_task_id
     FILTER_BY_RETRIEVAL_TASK_ID: Callable = filter_by_retrieval_task_id
+    FILTER_BY_RETRIEVED_BEFORE: Callable = filter_by_retrieved_before
 
 
 def apply_archive_filter(
-    archives: Query, filter_functions: list[ArchiveFilter], task_id: int = None
+    archives: Query,
+    filter_functions: list[ArchiveFilter],
+    task_id: int = None,
+    date: datetime = None,
 ) -> Query:
     """Apply filtering functions to archives and return filtered Query."""
     for filter_function in filter_functions:
-        archives: Query = filter_function(archives=archives, task_id=task_id)
+        archives: Query = filter_function(archives=archives, task_id=task_id, date=date)
     return archives

--- a/housekeeper/store/filters/archive_filters.py
+++ b/housekeeper/store/filters/archive_filters.py
@@ -32,9 +32,9 @@ def filter_by_retrieval_task_id(archives: Query, task_id: int, **kwargs) -> Quer
     return archives.filter(Archive.retrieval_task_id == task_id)
 
 
-def filter_by_retrieved_before(archives: Query, date: datetime, **kwargs) -> Query:
+def filter_by_retrieved_before(archives: Query, retrieved_before: datetime, **kwargs) -> Query:
     """Returns archives which were retrieved before the given date."""
-    return archives.filter(Archive.retrieved_at < date)
+    return archives.filter(Archive.retrieved_at < retrieved_before)
 
 
 class ArchiveFilter(Enum):
@@ -51,9 +51,11 @@ def apply_archive_filter(
     archives: Query,
     filter_functions: list[ArchiveFilter],
     task_id: int = None,
-    date: datetime = None,
+    retrieved_before: datetime = None,
 ) -> Query:
     """Apply filtering functions to archives and return filtered Query."""
     for filter_function in filter_functions:
-        archives: Query = filter_function(archives=archives, task_id=task_id, date=date)
+        archives: Query = filter_function(
+            archives=archives, task_id=task_id, retrieved_before=retrieved_before
+        )
     return archives

--- a/tests/store/filters/test_archive_filters.py
+++ b/tests/store/filters/test_archive_filters.py
@@ -100,11 +100,11 @@ def test_filter_by_retrieved_before(
     archive.retrieved_at = retrieved_at
 
     # GIVEN that we want only files that were retrieved before 2023-06-06
-    date: datetime = datetime.datetime(year=2023, month=6, day=6)
+    retrieved_before: datetime = datetime.datetime(year=2023, month=6, day=6)
 
     # WHEN filtering by when it was retrieved
     archives_retrieved_before_date: list[Archive] = filter_by_retrieved_before(
-        archives=populated_store._get_query(table=Archive), date=date
+        archives=populated_store._get_query(table=Archive), retrieved_before=retrieved_before
     ).all()
 
     # THEN the archive is only returned if it was retrieved before date

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -320,9 +320,7 @@ def test_filter_by_retrieved_before(
     date: datetime = datetime.datetime(year=2023, month=6, day=6)
 
     # WHEN filtering by when it was retrieved
-    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(
-        retrieved_before=date
-    )
+    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(date=date)
 
     # THEN the archive is only returned if it was retrieved before date
     assert (archive.file in files_retrieved_before_date) == should_be_returned

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -1,4 +1,5 @@
 """Tests for finding tags in store."""
+import datetime
 from datetime import timedelta
 from pathlib import Path
 
@@ -293,3 +294,32 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
             assert archive in selected_archives
         else:
             assert archive not in selected_archives
+
+
+@pytest.mark.parametrize(
+    "retrieved_at, should_be_returned",
+    [
+        (datetime.datetime(year=2023, month=12, day=12), False),
+        (datetime.datetime(year=2023, month=1, day=1), True),
+    ],
+)
+def test_filter_by_retrieved_before(
+    archive: Archive,
+    retrieval_task_id: int,
+    populated_store: Store,
+    retrieved_at: datetime,
+    should_be_returned: bool,
+):
+    """Tests filtering archives on only those retrieved before a given date."""
+    # GIVEN a store with an archive with the given retrieval task id and which was retrieved at the given time
+    archive.retrieval_task_id = retrieval_task_id
+    archive.retrieved_at = retrieved_at
+
+    # GIVEN that we want only files that were retrieved before 2023-06-06
+    date: datetime = datetime.datetime(year=2023, month=6, day=6)
+
+    # WHEN filtering by when it was retrieved
+    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(date=date)
+
+    # THEN the archive is only returned if it was retrieved before date
+    assert (archive.file in files_retrieved_before_date) == should_be_returned

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -301,6 +301,7 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
     [
         (datetime.datetime(year=2023, month=12, day=12), False),
         (datetime.datetime(year=2023, month=1, day=1), True),
+        (None, False),
     ],
 )
 def test_filter_by_retrieved_before(

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -320,7 +320,9 @@ def test_filter_by_retrieved_before(
     date: datetime = datetime.datetime(year=2023, month=6, day=6)
 
     # WHEN filtering by when it was retrieved
-    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(date=date)
+    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(
+        retrieved_before=date
+    )
 
     # THEN the archive is only returned if it was retrieved before date
     assert (archive.file in files_retrieved_before_date) == should_be_returned


### PR DESCRIPTION
## Description

When cleaning Spring files which have been retrieved via DDN, we have a need to filter files on when it was retrieved, since this will be used to discern if the spring file should be removed or not. This PR adds support for fetching files which were retrieved before a specified date.

### Added

- method get_files_retrieved_before

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy archiving-get-retrieved-files
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
