### PR TITLE
(Archiving) Filter on tags in get_retrieved_files

### DIFF
--- a/housekeeper/store/api/handlers/read.py
+++ b/housekeeper/store/api/handlers/read.py
@@ -271,10 +271,19 @@ class ReadHandler(BaseHandler):
             task_id=retrieval_task_id,
         ).all()
 
-    def get_files_retrieved_before(self, date: datetime):
+    def get_files_retrieved_before(
+        self, date: datetime, tag_names: list[str] | None = None
+    ) -> list[File]:
         """Returns all files which were retrieved before the given date."""
-        return apply_archive_filter(
+        old_enough_files: Query = apply_archive_filter(
             archives=self._get_join_file_tags_archive_query(),
             filter_functions=[ArchiveFilter.FILTER_BY_RETRIEVED_BEFORE],
             retrieved_before=date,
         )
+        if tag_names:
+            return apply_file_filter(
+                files=old_enough_files,
+                filter_functions=[FileFilter.FILTER_FILES_BY_TAGS],
+                tag_names=tag_names,
+            ).all()
+        return old_enough_files.all()

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -297,11 +297,13 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
 
 
 @pytest.mark.parametrize(
-    "retrieved_at, should_be_returned",
+    "retrieved_at, tags, should_be_returned",
     [
-        (datetime.datetime(year=2023, month=12, day=12), False),
-        (datetime.datetime(year=2023, month=1, day=1), True),
-        (None, False),
+        (datetime.datetime(year=2023, month=12, day=12), [], False),
+        (datetime.datetime(year=2023, month=1, day=1), [], True),
+        (datetime.datetime(year=2023, month=1, day=1), ["spring"], True),
+        (datetime.datetime(year=2023, month=1, day=1), ["fastq"], False),
+        (None, [], False),
     ],
 )
 def test_filter_by_retrieved_before(
@@ -309,18 +311,21 @@ def test_filter_by_retrieved_before(
     retrieval_task_id: int,
     populated_store: Store,
     retrieved_at: datetime,
+    tags: list[str],
     should_be_returned: bool,
 ):
-    """Tests filtering archives on only those retrieved before a given date."""
+    """Tests filtering archives on only those retrieved before a given date or tagged with the given tags."""
     # GIVEN a store with an archive with the given retrieval task id and which was retrieved at the given time
     archive.retrieval_task_id = retrieval_task_id
     archive.retrieved_at = retrieved_at
 
-    # GIVEN that we want only files that were retrieved before 2023-06-06
+    # GIVEN that we want only files that were retrieved before 2023-06-06 and tagged with the provided tags
     date: datetime = datetime.datetime(year=2023, month=6, day=6)
 
     # WHEN filtering by when it was retrieved
-    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(date=date)
+    files_retrieved_before_date: list[File] = populated_store.get_files_retrieved_before(
+        date=date, tag_names=tags
+    )
 
     # THEN the archive is only returned if it was retrieved before date
     assert (archive.file in files_retrieved_before_date) == should_be_returned

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -305,6 +305,13 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
         (datetime.datetime(year=2023, month=1, day=1), ["fastq"], False),
         (None, [], False),
     ],
+    ids=[
+        "Newly retrieved file",
+        "Old retrieved file",
+        "Old retrieved Spring file",
+        "Old retrieved Fastq file",
+        "Not retrieved file",
+    ],
 )
 def test_filter_by_retrieved_before(
     archive: Archive,

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -306,7 +306,7 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
         (None, [], False),
     ],
     ids=[
-        "Newly retrieved file",
+        "Nwly retrieved file",
         "Old retrieved file",
         "Old retrieved Spring file",
         "Old retrieved Fastq file",

--- a/tests/store/handlers/test_readhandler.py
+++ b/tests/store/handlers/test_readhandler.py
@@ -306,7 +306,7 @@ def test_archives_not_returned_via_retrieval_id(retrieval_task_id: int, populate
         (None, [], False),
     ],
     ids=[
-        "Nwly retrieved file",
+        "Newly retrieved file",
         "Old retrieved file",
         "Old retrieved Spring file",
         "Old retrieved Fastq file",


### PR DESCRIPTION
## Description

This PR adds support for filtering on tags when getting retrieved files.

### Added

- Tag filtering in get_retrieved_files

## Testing

### How to prepare for test

- [x] ssh to Hasta
- [x] Test your branch with

```bash
housekeeper-test-deploy archiving-filter-on-tags
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
