### PR TITLE
feat(CLI get) Improve get bundle command

### DIFF
--- a/housekeeper/cli/get.py
+++ b/housekeeper/cli/get.py
@@ -28,7 +28,6 @@ def get():
 @click.argument("bundle-name", required=False)
 @click.option("-i", "--bundle-id", type=int, help="Search for a bundle with bundle id")
 @click.option("-j", "--json", is_flag=True, help="Output to json format")
-@click.option("-v", "--verbose", is_flag=True, help="List files from latest version")
 @click.option(
     "-c",
     "--compact",
@@ -36,7 +35,7 @@ def get():
     help="print compact filenames IFF verobe flag present",
 )
 @click.pass_context
-def bundle_cmd(context, bundle_name, bundle_id, json, verbose, compact):
+def bundle_cmd(context, bundle_name, bundle_id, json, compact):
     """Get bundle information from database"""
     store: Store = context.obj["store"]
     bundles = store.bundles()
@@ -62,13 +61,12 @@ def bundle_cmd(context, bundle_name, bundle_id, json, verbose, compact):
         return
     console = Console()
     console.print(get_bundles_table(result))
-    if verbose:
-        for bundle in bundles:
-            if len(bundle.versions) == 0:
-                LOG.info("No versions found for bundle %s", bundle.name)
-                return
-            version_obj = bundle.versions[0]
-            context.invoke(version_cmd, version_id=version_obj.id, verbose=True, compact=compact)
+    for bundle in bundles:
+        if len(bundle.versions) == 0:
+            LOG.info("No versions found for bundle %s", bundle.name)
+            return
+        version_obj = bundle.versions[0]
+        context.invoke(version_cmd, version_id=version_obj.id, verbose=True, compact=compact)
 
 
 @get.command("version")

--- a/housekeeper/cli/tables.py
+++ b/housekeeper/cli/tables.py
@@ -42,7 +42,7 @@ def get_files_table(rows: list[dict], verbose=False, compact=False) -> Table:
         if i % 2 == 0:
             table.add_row(str(file_obj["id"]), f"[yellow]{file_name}[/yellow]", file_tags)
         else:
-            table.add_row(str(file_obj["id"]), f"[blue]{file_name}[/blue]", file_tags)
+            table.add_row(str(file_obj["id"]), f"[cyan]{file_name}[/cyan]", file_tags)
     return table
 
 


### PR DESCRIPTION
## Description
The CLI command `housekeeper get bundle` is always used with the -v flag and the output is hard to read. (see linked issue)

### Changed

- The verbose option is now always passed in `housekeeper get bundle`
- Deep blue text colour changed to cyan