### PR TITLE
Add cryptography to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Click
 coloredlogs
+cryptography
 marshmallow
 pyyaml
 SQLAlchemy


### PR DESCRIPTION
## Description
SQLAlchemy needs the cryptography package to be installed to authenticate vs mysql using hashed passwords
### Added

- cryptography package to requirements

