### PR TITLE
129 add file already in bundle directory

### DIFF
--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -133,7 +133,9 @@ def file_cmd(
     tags = data.get("tags", tags)
     if not keep_input_path:
         version: Version = bundle.versions[0]
-        housekeeper_file_path: Path = Path(context.obj[ROOT], version.relative_root_dir, file_path.name)
+        housekeeper_file_path: Path = Path(
+            context.obj[ROOT], version.relative_root_dir, file_path.name
+        )
         if housekeeper_file_path.exists():
             if not Path.samefile(housekeeper_file_path, path):
                 LOG.warning("A file with the same name already exists in %s.", file_path)

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -13,11 +13,10 @@ from housekeeper.date import get_date
 from housekeeper.exc import VersionIncludedError
 from housekeeper.files import load_json, validate_input
 from housekeeper.include import (
-    different_file_with_same_name_exists_in_bundle_directory,
-    file_exists_in_bundle_directory,
     include_version,
     link_to_relative_path,
     relative_path,
+    same_file_exists_in_bundle_directory,
 )
 from housekeeper.store.models import Bundle, Tag, Version
 from housekeeper.store.store import Store
@@ -141,29 +140,12 @@ def file_cmd(
     if keep_input_path:
         housekeeper_file_path: Path = file_path
 
-    if different_file_with_same_name_exists_in_bundle_directory(
-        file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
-    ):
-        housekeeper_file_path: Path = Path(
-            context.obj[ROOT], version.relative_root_dir, file_path.name
-        )
-        LOG.warning(
-            "A different file with the same name already exists in the bundle at %s.",
-            housekeeper_file_path,
-        )
-        raise click.Abort
-
-    if file_exists_in_bundle_directory(
-        file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
-    ):
-        housekeeper_file_path: Path = relative_path(version=version, file=file_path)
-
-    if not file_exists_in_bundle_directory(
+    if not same_file_exists_in_bundle_directory(
         file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
     ):
         link_to_relative_path(version=version, file_path=file_path, root_path=context.obj[ROOT])
-        housekeeper_file_path: Path = relative_path(version=version, file=file_path)
 
+    housekeeper_file_path: Path = relative_path(version=version, file=file_path)
     new_file = store.add_file(file_path=housekeeper_file_path, bundle=bundle, tags=tags)
     store.session.add(new_file)
     store.session.commit()

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -12,11 +12,15 @@ from housekeeper.constants import ROOT
 from housekeeper.date import get_date
 from housekeeper.exc import VersionIncludedError
 from housekeeper.files import load_json, validate_input
-from housekeeper.include import include_version, link_file, relative_path, file_exists_in_bundle_directory, \
-    link_to_relative_path, different_file_with_same_name_exists_in_bundle_directory
+from housekeeper.include import (
+    different_file_with_same_name_exists_in_bundle_directory,
+    file_exists_in_bundle_directory,
+    include_version,
+    link_to_relative_path,
+    relative_path,
+)
 from housekeeper.store.models import Bundle, Tag, Version
 from housekeeper.store.store import Store
-from tests.conftest import db_name
 
 LOG: Logger = logging.getLogger(__name__)
 
@@ -135,15 +139,24 @@ def file_cmd(
     tags = data.get("tags", tags)
     version: Version = bundle.versions[0]
     if not keep_input_path:
-        if different_file_with_same_name_exists_in_bundle_directory(file_path=file_path, bundle_root_path=context.obj[ROOT], version=version):
+        if different_file_with_same_name_exists_in_bundle_directory(
+            file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
+        ):
             housekeeper_file_path: Path = Path(
                 context.obj[ROOT], version.relative_root_dir, file_path.name
             )
-            LOG.warning("A different file with the same name already exists in the bundle at %s.", housekeeper_file_path)
+            LOG.warning(
+                "A different file with the same name already exists in the bundle at %s.",
+                housekeeper_file_path,
+            )
             raise click.Abort
-        if file_exists_in_bundle_directory(file_path=file_path, bundle_root_path=context.obj[ROOT], version=version):
+        if file_exists_in_bundle_directory(
+            file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
+        ):
             file_path: Path = relative_path(version=version, file=file_path)
-        if not file_exists_in_bundle_directory:
+        if not file_exists_in_bundle_directory(
+            file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
+        ):
             link_to_relative_path(version=version, file_path=file_path, root_path=context.obj[ROOT])
             file_path: Path = relative_path(version=version, file=file_path)
 

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -12,7 +12,7 @@ from housekeeper.constants import ROOT
 from housekeeper.date import get_date
 from housekeeper.exc import VersionIncludedError
 from housekeeper.files import load_json, validate_input
-from housekeeper.include import include_version, relative_path, link_file
+from housekeeper.include import include_version, link_file, relative_path
 from housekeeper.store.models import Bundle, Tag, Version
 from housekeeper.store.store import Store
 

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -138,29 +138,33 @@ def file_cmd(
 
     tags = data.get("tags", tags)
     version: Version = bundle.versions[0]
-    if not keep_input_path:
-        if different_file_with_same_name_exists_in_bundle_directory(
-            file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
-        ):
-            housekeeper_file_path: Path = Path(
-                context.obj[ROOT], version.relative_root_dir, file_path.name
-            )
-            LOG.warning(
-                "A different file with the same name already exists in the bundle at %s.",
-                housekeeper_file_path,
-            )
-            raise click.Abort
-        if file_exists_in_bundle_directory(
-            file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
-        ):
-            file_path: Path = relative_path(version=version, file=file_path)
-        if not file_exists_in_bundle_directory(
-            file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
-        ):
-            link_to_relative_path(version=version, file_path=file_path, root_path=context.obj[ROOT])
-            file_path: Path = relative_path(version=version, file=file_path)
+    if keep_input_path:
+        housekeeper_file_path: Path = file_path
 
-    new_file = store.add_file(file_path=file_path, bundle=bundle, tags=tags)
+    if different_file_with_same_name_exists_in_bundle_directory(
+        file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
+    ):
+        housekeeper_file_path: Path = Path(
+            context.obj[ROOT], version.relative_root_dir, file_path.name
+        )
+        LOG.warning(
+            "A different file with the same name already exists in the bundle at %s.",
+            housekeeper_file_path,
+        )
+        raise click.Abort
+
+    if file_exists_in_bundle_directory(
+        file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
+    ):
+        housekeeper_file_path: Path = relative_path(version=version, file=file_path)
+
+    if not file_exists_in_bundle_directory(
+        file_path=file_path, bundle_root_path=context.obj[ROOT], version=version
+    ):
+        link_to_relative_path(version=version, file_path=file_path, root_path=context.obj[ROOT])
+        housekeeper_file_path: Path = relative_path(version=version, file=file_path)
+
+    new_file = store.add_file(file_path=housekeeper_file_path, bundle=bundle, tags=tags)
     store.session.add(new_file)
     store.session.commit()
     LOG.info("new file added: %s (%s)", new_file.path, new_file.id)

--- a/housekeeper/cli/add.py
+++ b/housekeeper/cli/add.py
@@ -137,6 +137,7 @@ def file_cmd(
             context.obj[ROOT], version.relative_root_dir, file_path.name
         )
         if housekeeper_file_path.exists():
+            LOG.warning("File %s already exists.", file_path)
             if not Path.samefile(housekeeper_file_path, path):
                 LOG.warning("A file with the same name already exists in %s.", file_path)
                 raise click.Abort

--- a/housekeeper/cli/include.py
+++ b/housekeeper/cli/include.py
@@ -14,11 +14,11 @@ LOG = logging.getLogger(__name__)
 
 
 @click.command()
-@click.option("--version-id", type=int, help="version id of the bundle version")
+@c<lick.option("--version-id", type=int, help="version id of the bundle version")
 @click.argument("bundle_name", required=False)
 @click.pass_context
 def include(context: click.Context, bundle_name: str, version_id: int):
-    """Include a bundle of files into the internal space.
+    """Include a b>undle of files into the internal space.
 
     Use bundle name if you simply want to include the latest version.
     """

--- a/housekeeper/cli/include.py
+++ b/housekeeper/cli/include.py
@@ -14,11 +14,11 @@ LOG = logging.getLogger(__name__)
 
 
 @click.command()
-@c<lick.option("--version-id", type=int, help="version id of the bundle version")
+@click.option("--version-id", type=int, help="version id of the bundle version")
 @click.argument("bundle_name", required=False)
 @click.pass_context
 def include(context: click.Context, bundle_name: str, version_id: int):
-    """Include a b>undle of files into the internal space.
+    """Include a bundle of files into the internal space.
 
     Use bundle name if you simply want to include the latest version.
     """

--- a/housekeeper/include.py
+++ b/housekeeper/include.py
@@ -58,11 +58,5 @@ def checksum(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def link_to_relative_path(file_path: Path, root_path: Path, version: Version) -> None:
-    """Link the given absolute path to its path when included in the given version and return the relative path."""
-    housekeeper_path: Path = Path(root_path, version.relative_root_dir, file_path.name)
-    link_file(file_path=file_path, new_path=housekeeper_path, hardlink=True)
-
-
 def relative_path(version: Version, file: Path) -> Path:
     return Path(version.relative_root_dir, file.name)

--- a/housekeeper/include.py
+++ b/housekeeper/include.py
@@ -57,6 +57,23 @@ def checksum(path: Path) -> str:
             buf = stream.read(BLOCKSIZE)
     return hasher.hexdigest()
 
+def different_file_with_same_name_exists_in_bundle_directory(file_path: Path, bundle_root_path=Path, version= Version) -> bool:
+    housekeeper_file_path: Path = Path(
+        bundle_root_path, version.relative_root_dir, file_path.name
+    )
+    return housekeeper_file_path.exists() and not Path.samefile(file_path, housekeeper_file_path)
+
+def file_exists_in_bundle_directory(file_path: Path, bundle_root_path=Path, version= Version) -> bool:
+    housekeeper_file_path: Path = Path(
+        bundle_root_path, version.relative_root_dir, file_path.name
+    )
+    return housekeeper_file_path.exists() and Path.samefile(file_path, housekeeper_file_path)
+
+def link_to_relative_path(file_path: Path, root_path: Path, version: Version) -> None:
+    """Link the given absolute path to the path of the given bundle version."""
+    housekeeper_path: Path = Path(root_path, version.relative_root_dir, file_path.name)
+    link_file(file_path=file_path, new_path=housekeeper_path, hardlink=True)
+
 
 def relative_path(version: Version, file: Path) -> Path:
     return Path(version.relative_root_dir, file.name)

--- a/housekeeper/include.py
+++ b/housekeeper/include.py
@@ -58,14 +58,7 @@ def checksum(path: Path) -> str:
     return hasher.hexdigest()
 
 
-def different_file_with_same_name_exists_in_bundle_directory(
-    file_path: Path, bundle_root_path=Path, version=Version
-) -> bool:
-    housekeeper_file_path: Path = Path(bundle_root_path, version.relative_root_dir, file_path.name)
-    return housekeeper_file_path.exists() and not Path.samefile(file_path, housekeeper_file_path)
-
-
-def file_exists_in_bundle_directory(
+def same_file_exists_in_bundle_directory(
     file_path: Path, bundle_root_path=Path, version=Version
 ) -> bool:
     housekeeper_file_path: Path = Path(bundle_root_path, version.relative_root_dir, file_path.name)

--- a/housekeeper/include.py
+++ b/housekeeper/include.py
@@ -57,17 +57,20 @@ def checksum(path: Path) -> str:
             buf = stream.read(BLOCKSIZE)
     return hasher.hexdigest()
 
-def different_file_with_same_name_exists_in_bundle_directory(file_path: Path, bundle_root_path=Path, version= Version) -> bool:
-    housekeeper_file_path: Path = Path(
-        bundle_root_path, version.relative_root_dir, file_path.name
-    )
+
+def different_file_with_same_name_exists_in_bundle_directory(
+    file_path: Path, bundle_root_path=Path, version=Version
+) -> bool:
+    housekeeper_file_path: Path = Path(bundle_root_path, version.relative_root_dir, file_path.name)
     return housekeeper_file_path.exists() and not Path.samefile(file_path, housekeeper_file_path)
 
-def file_exists_in_bundle_directory(file_path: Path, bundle_root_path=Path, version= Version) -> bool:
-    housekeeper_file_path: Path = Path(
-        bundle_root_path, version.relative_root_dir, file_path.name
-    )
+
+def file_exists_in_bundle_directory(
+    file_path: Path, bundle_root_path=Path, version=Version
+) -> bool:
+    housekeeper_file_path: Path = Path(bundle_root_path, version.relative_root_dir, file_path.name)
     return housekeeper_file_path.exists() and Path.samefile(file_path, housekeeper_file_path)
+
 
 def link_to_relative_path(file_path: Path, root_path: Path, version: Version) -> None:
     """Link the given absolute path to the path of the given bundle version."""

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -208,9 +208,8 @@ def test_add_file_in_bundle_directory(
     version_obj: Version = bundle_obj.versions[0]
 
     # GIVEN that the file is in the bundle directory
-    file_in_housekeeper_bundle: Path = Path(
-        housekeeper_version_dir, "file_in_housekeeper_bundle.txt"
-    )
+    file_name: str = "file_in_housekeeper_bundle.txt"
+    file_in_housekeeper_bundle: Path = Path(housekeeper_version_dir, file_name)
     open(file_in_housekeeper_bundle, "w").close()
 
     # WHEN trying to add a file with the same name to the bundle
@@ -226,7 +225,7 @@ def test_add_file_in_bundle_directory(
     assert NEW_FILE_ADDED in caplog.text
     # THEN check that the file was added to the housekeeper bundle version
     housekeeper_files: list[Path] = [Path(file.path) for file in version_obj.files]
-    assert file_in_housekeeper_bundle in housekeeper_files
+    assert Path(version_obj.relative_root_dir, file_name) in housekeeper_files
 
 
 def test_add_file_json(

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -164,6 +164,10 @@ def test_add_file_when_different_file_with_same_name_exists_in_bundle_directory(
     # GIVEN a context with a populated store and a cli runner
     bundle_name = case_id
 
+    store: Store = populated_context["store"]
+    bundle_obj: Bundle = store.bundles().first()
+    version_obj: Version = bundle_obj.versions[0]
+
     # GIVEN that there is a file in the bundle directory
     file_in_housekeeper_bundle: Path = Path(housekeeper_version_dir, second_sample_vcf.name)
     open(file_in_housekeeper_bundle, "w").close()
@@ -177,6 +181,11 @@ def test_add_file_when_different_file_with_same_name_exists_in_bundle_directory(
 
     # THEN assert it fails
     assert result.exit_code == 1
+    # THEN check that an error message is displayed
+    assert "File exists." in caplog.text
+    # THEN check that the file was not added to the housekeeper bundle version
+    housekeeper_files: list[Path] = [Path(file.path) for file in version_obj.files]
+    assert file_in_housekeeper_bundle not in housekeeper_files
 
 
 def test_add_file_in_bundle_directory(

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -97,7 +97,7 @@ def test_add_file_existing_bundle_with_include(
     housekeeper_version_dir: Path,
     project_dir: Path,
 ):
-    """Test to add a file to a existing bundle"""
+    """Test to add a file to an existing bundle"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
     bundle_name = case_id
@@ -113,7 +113,7 @@ def test_add_file_existing_bundle_with_include(
         obj=populated_context,
     )
 
-    # THEN assert it succedes
+    # THEN assert it succeeds
     assert result.exit_code == 0
     # THEN check that the proper information is displayed
     assert NEW_FILE_ADDED in caplog.text

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -88,7 +88,7 @@ def test_add_non_existing_file(base_context: Context, cli_runner: CliRunner, cap
     assert f"File: {non_existing} does not exist" in caplog.text
 
 
-def test_add_file_existing_bundle_with_include(
+def test_add_new_file_existing_bundle_with_include(
     populated_context: dict,
     cli_runner: CliRunner,
     case_id: str,
@@ -97,7 +97,7 @@ def test_add_file_existing_bundle_with_include(
     housekeeper_version_dir: Path,
     project_dir: Path,
 ):
-    """Test to add a file to an existing bundle"""
+    """Test to add a new file to an existing bundle"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
     bundle_name = case_id
@@ -125,7 +125,7 @@ def test_add_file_existing_bundle_with_include(
     )
 
 
-def test_add_file_existing_bundle_without_include(
+def test_add_new_file_existing_bundle_without_include(
     populated_context: Context,
     cli_runner: CliRunner,
     case_id: str,
@@ -133,7 +133,7 @@ def test_add_file_existing_bundle_without_include(
     caplog,
     housekeeper_version_dir: Path,
 ):
-    """Test to add a file to a existing bundle"""
+    """Test to add a file to an existing bundle"""
     caplog.set_level(logging.DEBUG)
     # GIVEN a context with a populated store and a cli runner
     bundle_name = case_id
@@ -149,6 +149,84 @@ def test_add_file_existing_bundle_without_include(
     assert result.exit_code == 0
     # THEN check that the proper information is displayed
     assert NEW_FILE_ADDED in caplog.text
+
+
+def test_add_file_when_different_file_with_same_name_exists_in_bundle_directory(
+    populated_context: dict,
+    cli_runner: CliRunner,
+    case_id: str,
+    second_sample_vcf: Path,
+    housekeeper_version_dir: Path,
+    caplog,
+):
+    """Test adding a file to an existing bundle when a different file with the same name already exists in the bundle directory."""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a context with a populated store and a cli runner
+    bundle_name = case_id
+
+    store: Store = populated_context["store"]
+    bundle_obj: Bundle = store.bundles().first()
+    version_obj: Version = bundle_obj.versions[0]
+
+    # GIVEN that there is a file in the bundle directory
+    file_in_housekeeper_bundle: Path = Path(housekeeper_version_dir, second_sample_vcf.name)
+    open(file_in_housekeeper_bundle, "w").close()
+
+    # WHEN trying to add a file with the same name to the bundle
+    result = cli_runner.invoke(
+        file_cmd,
+        [str(second_sample_vcf), "-b", bundle_name],
+        obj=populated_context,
+    )
+
+    # THEN assert it fails
+    assert result.exit_code == 1
+    # THEN check that an error message is displayed
+    assert (
+        f"A different file with the same name already exists in the bundle at {file_in_housekeeper_bundle}."
+        in caplog.text
+    )
+    # THEN check that the file was not added to the housekeeper bundle version
+    housekeeper_files: list[Path] = [Path(file.path) for file in version_obj.files]
+    assert file_in_housekeeper_bundle not in housekeeper_files
+
+
+def test_add_file_in_bundle_directory(
+    populated_context: dict,
+    cli_runner: CliRunner,
+    case_id: str,
+    housekeeper_version_dir: Path,
+    caplog,
+):
+    """Test adding a file to an existing bundle given that the file is in the bundle directory."""
+    caplog.set_level(logging.DEBUG)
+    # GIVEN a context with a populated store and a cli runner
+    bundle_name = case_id
+
+    store: Store = populated_context["store"]
+    bundle_obj: Bundle = store.bundles().first()
+    version_obj: Version = bundle_obj.versions[0]
+
+    # GIVEN that the file is in the bundle directory
+    file_in_housekeeper_bundle: Path = Path(
+        housekeeper_version_dir, "file_in_housekeeper_bundle.txt"
+    )
+    open(file_in_housekeeper_bundle, "w").close()
+
+    # WHEN trying to add a file with the same name to the bundle
+    result = cli_runner.invoke(
+        file_cmd,
+        [str(file_in_housekeeper_bundle), "-b", bundle_name],
+        obj=populated_context,
+    )
+
+    # THEN assert it succeeds
+    assert result.exit_code == 0
+    # THEN check that the proper information is displayed
+    assert NEW_FILE_ADDED in caplog.text
+    # THEN check that the file was added to the housekeeper bundle version
+    housekeeper_files: list[Path] = [Path(file.path) for file in version_obj.files]
+    assert file_in_housekeeper_bundle in housekeeper_files
 
 
 def test_add_file_json(

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -182,7 +182,7 @@ def test_add_file_when_different_file_with_same_name_exists_in_bundle_directory(
     # THEN assert it fails
     assert result.exit_code == 1
     # THEN check that an error message is displayed
-    assert "File exists." in caplog.text
+    assert "linked file:" not in caplog.text
     # THEN check that the file was not added to the housekeeper bundle version
     housekeeper_files: list[Path] = [Path(file.path) for file in version_obj.files]
     assert file_in_housekeeper_bundle not in housekeeper_files

--- a/tests/cli/add/test_cli_add_file.py
+++ b/tests/cli/add/test_cli_add_file.py
@@ -164,10 +164,6 @@ def test_add_file_when_different_file_with_same_name_exists_in_bundle_directory(
     # GIVEN a context with a populated store and a cli runner
     bundle_name = case_id
 
-    store: Store = populated_context["store"]
-    bundle_obj: Bundle = store.bundles().first()
-    version_obj: Version = bundle_obj.versions[0]
-
     # GIVEN that there is a file in the bundle directory
     file_in_housekeeper_bundle: Path = Path(housekeeper_version_dir, second_sample_vcf.name)
     open(file_in_housekeeper_bundle, "w").close()
@@ -181,14 +177,6 @@ def test_add_file_when_different_file_with_same_name_exists_in_bundle_directory(
 
     # THEN assert it fails
     assert result.exit_code == 1
-    # THEN check that an error message is displayed
-    assert (
-        f"A different file with the same name already exists in the bundle at {file_in_housekeeper_bundle}."
-        in caplog.text
-    )
-    # THEN check that the file was not added to the housekeeper bundle version
-    housekeeper_files: list[Path] = [Path(file.path) for file in version_obj.files]
-    assert file_in_housekeeper_bundle not in housekeeper_files
 
 
 def test_add_file_in_bundle_directory(


### PR DESCRIPTION
## Description

Closes https://github.com/Clinical-Genomics/housekeeper/issues/129.

### Changed

- Change logic in housekeeper add file to check if the file exists in the bundle directory and skip hard linking if the given file is the one already in the bundle directory.
- If there already is a file with the same name in the bundle directory, the command aborts and to file should be hard linked to the directory or added to housekeeper in order to not override the original file.
- Removed function `link_to_housekeeper_path` as it is unused given the new logic.

## Testing

### How to test
- [x] Pytest tests included

## Review
- [ ] code approved by
- [x] tests executed by BSV
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
