### PR TITLE
Add retrieval ongoing distinction to store methods

### DIFF
--- a/housekeeper/services/file_report_service/file_report_service.py
+++ b/housekeeper/services/file_report_service/file_report_service.py
@@ -6,7 +6,6 @@ import json as jsonlib
 
 
 class FileReportService:
-
     def __init__(self, compact: bool = False, json: bool = False):
         self.console = Console()
         self.compact = compact

--- a/housekeeper/services/file_service/file_service.py
+++ b/housekeeper/services/file_service/file_service.py
@@ -3,7 +3,6 @@ from housekeeper.store.store import Store
 
 
 class FileService:
-
     def __init__(self, store: Store):
         self.store = store
 


### PR DESCRIPTION
## Description

We need to distinguish between files which are archived but not being retrieved and files which are currently being retrieved, to combat files getting fetched back multiple times over when transfer speed are slow.

### Added

- New method in the store for getting archived files, excluding files which are currently being retrieved

### Changed

- Renamed old method to clarify that it includes files which are being retrieved currently

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy <branch-name>
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
