### PR TITLE
add support for filtering out ongoing archival processes

### DIFF
--- a/housekeeper/store/crud/read.py
+++ b/housekeeper/store/crud/read.py
@@ -178,12 +178,19 @@ class ReadHandler(BaseHandler):
     def get_archived_files_for_bundle_excluding_ongoing_retrievals(
         self, bundle_name: str, tags: list | None
     ) -> list[File]:
-        """Returns all files in the given bundle, with the given tags, that are archived."""
+        """
+        Returns files in the given bundle with the given tags (if provided)
+        that have been successfully archived and don't have ongoing retrieval processes.
+        """
         archived_files: Query = self._get_archived_files_for_bundle(
             bundle_name=bundle_name, tags=tags
         )
         return apply_archive_filter(
-            archives=archived_files, filter_functions=[ArchiveFilter.RETRIEVAL_NOT_ONGOING]
+            archives=archived_files,
+            filter_functions=[
+                ArchiveFilter.ARCHIVING_COMPLETED,
+                ArchiveFilter.RETRIEVAL_NOT_ONGOING,
+            ],
         ).all()
 
     def _get_archived_files_for_bundle(self, bundle_name: str, tags: list | None) -> Query:

--- a/housekeeper/store/crud/update.py
+++ b/housekeeper/store/crud/update.py
@@ -8,10 +8,7 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 
 from housekeeper.store.base import BaseHandler
-from housekeeper.store.filters.archive_filters import (
-    ArchiveFilter,
-    apply_archive_filter,
-)
+from housekeeper.store.filters.archive_filters import ArchiveFilter, apply_archive_filter
 from housekeeper.store.models import Archive
 
 LOG = logging.getLogger(__name__)
@@ -50,7 +47,7 @@ class UpdateHandler(BaseHandler):
             self.update_archiving_time_stamp(archive=archive)
 
     def update_finished_retrieval_task(self, retrieval_task_id: int) -> None:
-        """Sets the archived_at field to now for all archives with the given archiving task id."""
+        """Sets the retrieved_at field to now for all archives with the given retrieving task id."""
         completed_archives: list[Archive] = apply_archive_filter(
             archives=self._get_query(table=Archive),
             filter_functions=[ArchiveFilter.BY_RETRIEVAL_TASK_ID],

--- a/housekeeper/store/filters/archive_filters.py
+++ b/housekeeper/store/filters/archive_filters.py
@@ -8,25 +8,32 @@ from sqlalchemy.sql.elements import BooleanClauseList
 
 from housekeeper.store.models import Archive
 
-ARCHIVING_ONGOING: BooleanClauseList = and_(Archive.archiving_task_id, Archive.archived_at == None)
-RETRIEVAL_ONGOING: BooleanClauseList = and_(Archive.retrieval_task_id, Archive.retrieved_at == None)
-RETRIEVAL_NOT_ONGOING: BooleanClauseList = not_(
+_ARCHIVING_ONGOING: BooleanClauseList = and_(Archive.archiving_task_id, Archive.archived_at == None)
+_ARCHIVING_COMPLETED: BooleanClauseList = and_(Archive.archiving_task_id, Archive.archived_at)
+_RETRIEVAL_ONGOING: BooleanClauseList = and_(
+    Archive.retrieval_task_id, Archive.retrieved_at == None
+)
+_RETRIEVAL_NOT_ONGOING: BooleanClauseList = not_(
     and_(Archive.retrieval_task_id != None, Archive.retrieved_at == None)
 )
 
 
 def filter_archiving_ongoing(archives: Query, **kwargs) -> Query:
     """Return archives where the archiving is not marked as completed."""
-    return archives.filter(ARCHIVING_ONGOING)
+    return archives.filter(_ARCHIVING_ONGOING)
+
+
+def filter_archiving_completed(archives: Query, **kwargs) -> Query:
+    return archives.filter(_ARCHIVING_COMPLETED)
 
 
 def filter_retrieval_ongoing(archives: Query, **kwargs) -> Query:
     """Return archives where the retrieval is not marked as completed."""
-    return archives.filter(RETRIEVAL_ONGOING)
+    return archives.filter(_RETRIEVAL_ONGOING)
 
 
 def filter_retrieval_not_ongoing(archives: Query, **kwargs) -> Query:
-    return archives.filter(RETRIEVAL_NOT_ONGOING)
+    return archives.filter(_RETRIEVAL_NOT_ONGOING)
 
 
 def filter_by_archiving_task_id(archives: Query, task_id: int, **kwargs) -> Query:
@@ -48,6 +55,7 @@ class ArchiveFilter(Enum):
     """Define Archive filter functions."""
 
     ARCHIVING_ONGOING: Callable = filter_archiving_ongoing
+    ARCHIVING_COMPLETED: Callable = filter_archiving_completed
     RETRIEVAL_NOT_ONGOING: Callable = filter_retrieval_not_ongoing
     RETRIEVAL_ONGOING: Callable = filter_retrieval_ongoing
     BY_ARCHIVING_TASK_ID: Callable = filter_by_archiving_task_id

--- a/tests/store/conftest.py
+++ b/tests/store/conftest.py
@@ -111,6 +111,7 @@ def store_for_testing_getting_archived_files(store: Store) -> Store:
     archive_retrieval_ongoing = store.create_archive(
         file_id=archived_file_ongoing_retrieval.id, archiving_task_id=2
     )
+    archive_retrieval_not_ongoing.archived_at = datetime.datetime.now()
     archive_retrieved = store.create_archive(file_id=retrieved_file.id, archiving_task_id=3)
     archive_retrieval_ongoing.archived_at = datetime.datetime.now()
     archive_retrieval_ongoing.retrieval_task_id = 1


### PR DESCRIPTION
## Description
When we fetch the archived files for a bundle we currently exclude the archives with ongoing retrieval processes. We should, on top of that, filter out entries that have current archival processes, this is, entrie sin the `Archive` table that have an `archiving_task_id` but no `archival_date` set 

### Added

-

### Changed

-

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy <branch-name>
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
