### PR TITLE
Get files with ongoing retrievals for bundle

### DIFF
--- a/housekeeper/store/crud/read.py
+++ b/housekeeper/store/crud/read.py
@@ -236,6 +236,15 @@ class ReadHandler(BaseHandler):
             filter_functions=[ArchiveFilter.RETRIEVAL_ONGOING],
         ).all()
 
+    def get_files_with_ongoing_retrievals_for_bundle(
+        self, bundle_name: str, tags: list | None
+    ) -> list[File]:
+        """Returns all files in the given bundle, with the given tags, that have an ongoing retrieval."""
+        archived_files: Query = self._get_archived_files_for_bundle(bundle_name=bundle_name, tags=tags)
+        return apply_archive_filter(
+            archives=archived_files, filter_functions=[ArchiveFilter.RETRIEVAL_ONGOING]
+        ).all()
+
     def get_bundle_name_from_file_path(self, file_path: str) -> str:
         """Return the bundle name for the specified file."""
         return self.get_files(file_path=file_path).first().version.bundle.name

--- a/housekeeper/store/crud/read.py
+++ b/housekeeper/store/crud/read.py
@@ -240,7 +240,9 @@ class ReadHandler(BaseHandler):
         self, bundle_name: str, tags: list | None
     ) -> list[File]:
         """Returns all files in the given bundle, with the given tags, that have an ongoing retrieval."""
-        archived_files: Query = self._get_archived_files_for_bundle(bundle_name=bundle_name, tags=tags)
+        archived_files: Query = self._get_archived_files_for_bundle(
+            bundle_name=bundle_name, tags=tags
+        )
         return apply_archive_filter(
             archives=archived_files, filter_functions=[ArchiveFilter.RETRIEVAL_ONGOING]
         ).all()

--- a/tests/store/crud/test_readhandler.py
+++ b/tests/store/crud/test_readhandler.py
@@ -136,6 +136,25 @@ def test_get_archived_files_for_bundle_excluding_ongoing_retrievals(
     assert [file.path for file in files] == ["archived/file.txt", "retrieved/file.txt"]
 
 
+def test_get_files_with_ongoing_retrievals_for_bundle(
+    store_for_testing_getting_archived_files: Store,
+):
+    """Tests fetching archived SPRING files in a given bundle which are being retrieved."""
+    # GIVEN that the store contains a bundle, a version, and four files - one which is not archived,
+    # one which is archived and is not being retrieved, one which is archived and being retrieved
+    # and one which has been archived and retrieved
+
+    # WHEN asking for archived files which are being retrieved
+    files: list[File] = (
+        store_for_testing_getting_archived_files.get_files_with_ongoing_retrievals_for_bundle(
+            bundle_name="sample_id", tags=["spring"]
+        )
+    )
+
+    # THEN only the file with an ongoing retrieval should be returned
+    assert [file.path for file in files] == ["retrieval/ongoing/archived/file.txt"]
+
+
 def test_get_non_archived_files_for_bundle(
     archived_file: Path,
     non_archived_file: Path,


### PR DESCRIPTION
## Description

Basic feature for checking if a bundle has a file currently being retrieved.

### Added

- Get a function to know which files are being retrieved in the bundle.

### Changed

-

### Fixed

-

## Testing

### How to prepare for test

- [ ] ssh to Hasta
- [ ] Test your branch with

```bash
housekeeper-test-deploy <branch-name>
housekeeper-test <command here>
```
Any migrations need to be applied manually with alembic against the stage database.

### How to test
- [ ] login to ...
- [ ] do ...

### Expected test outcome
- [ ] check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
